### PR TITLE
fix(graphql): invalidate the GraphQL schema subtypes on new type

### DIFF
--- a/api/src/damnit_api/graphql/schema.py
+++ b/api/src/damnit_api/graphql/schema.py
@@ -31,6 +31,10 @@ class Schema(strawberry.Schema):
                                                        interfaces=[])
             implementations_map[interface] = implementations
 
+        # Invalidate the subtypes
+        graphql_schema._sub_type_map.pop(interface, None)
+
+        # Update the implementations objects
         for type_ in types:
             name = self._get_stype_name(type_)
 


### PR DESCRIPTION
This aims to fix the error of not being able to query subsequent proposals. We now invalidate the GraphQL schema sub type map, which will be populated on the next query with a type/fragment.

#### Steps to reproduce the problem:
1. Call the `refresh` mutation for the first proposal
2. Call the `runs` query for the first proposal
3. Call the `refresh` mutation for second proposal
4. Call the `runs` query for the second proposal
  - This will fail with the error: "Fragment cannot be spread here as objects of type 'DamnitRun' can never be of type '`p<PROPOSAL>`'."
