### PR TITLE
build: add authors and reset to v0.0.1

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,8 +1,11 @@
 [tool.poetry]
-name = "cammille-api"
-version = "0.1.0"
+name = "DAMNIT-web API"
+version = "0.0.1"
 description = ""
-authors = ["Your Name <you@example.com>"]
+authors = [
+  "Cammille Carinan <cammille.carinan@xfel.eu>",
+  "Robert Rosca <robert.rosca@xfel.eu>"
+]
 readme = "README.md"
 packages = [{ include = "damnit_api", from = "src" }]
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,11 @@
 {
   "name": "damnit-frontend",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.0.1",
+  "author": {
+    "name": "Cammille Carinan",
+    "email": "cammille.carinan@xfel.eu"
+  },
   "scripts": {
     "dev": "vite",
     "start": "vite",


### PR DESCRIPTION
Resetting the repos back to v0.0.1 and adding authors for completeness~

It would be great to have the monorepo version synced with the GitHub tag. Maybe this is something that you can look into @RobertRosca?

