### PR TITLE
Require Python 3.12 or above

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 packages = [{ include = "damnit_api", from = "src" }]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.12"
 pandas = "^2.0.1"
 sqlalchemy = { extras = ["asyncio"], version = "^2.0.19" }
 fastapi = "^0.104"


### PR DESCRIPTION
The API server code doesn't work on Python 3.10, even after my recent fixes, so let's just increase the required Python version.