### PR TITLE
feat(api/query): use run_variables table for database queries

### DIFF
--- a/api/tests/graphql/test_queries.py
+++ b/api/tests/graphql/test_queries.py
@@ -4,19 +4,29 @@ import pytest_asyncio
 from damnit_api.graphql.models import DamnitRun
 
 from .const import EXAMPLE_VALUES, EXAMPLE_VARIABLES, KNOWN_VALUES, NUM_ROWS
-from .utils import session_mock
+
+
+# TODO: Test with actual values without mocking the fetch functions
 
 
 @pytest_asyncio.fixture
-async def mocked_session(mocker):
+async def mocked_fetch_variables(mocker):
     mocker.patch(
-        "damnit_api.graphql.queries.get_session",
-        return_value=session_mock([{**KNOWN_VALUES, **EXAMPLE_VALUES}]),
+        "damnit_api.graphql.queries.fetch_variables",
+        return_value=[EXAMPLE_VALUES],
+    )
+
+
+@pytest_asyncio.fixture
+async def mocked_fetch_info(mocker):
+    mocker.patch(
+        "damnit_api.graphql.queries.fetch_info",
+        return_value=[KNOWN_VALUES],
     )
 
 
 @pytest.mark.asyncio
-async def test_runs_query(graphql_schema, mocked_session):
+async def test_runs_query(graphql_schema, mocked_fetch_variables, mocked_fetch_info):
     query = """
         query TableDataQuery($per_page: Int = 2) {
           runs(database: {proposal: "1234"}, per_page: $per_page) {

--- a/api/tests/graphql/utils.py
+++ b/api/tests/graphql/utils.py
@@ -1,8 +1,7 @@
-from unittest.mock import AsyncMock, Mock
+from typing import Optional
 
 from damnit_api.graphql.models import (
     DamnitRun,
-    DamnitType,
     DamnitVariable,
     KnownVariable,
 )
@@ -30,26 +29,6 @@ def create_run_info(proposal=1234, run=1, start_time=500, added_at=1000):
         "start_time": start_time,
         "added_at": added_at,
     }
-
-
-# -----------------------------------------------------------------------------
-# Mocks
-
-
-def session_mock(return_value):
-    mappings = Mock()
-    mappings.all.return_value = return_value
-
-    execute = Mock()
-    execute.mappings.return_value = mappings
-
-    session = Mock()
-    session.execute = AsyncMock(return_value=execute)
-
-    get_session = AsyncMock()
-    get_session.__aenter__.return_value = session
-
-    return get_session
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Now leveraging SQLAlchemy subqueries to fetch only what we need! This helps with the performance as joining the table to generate run-based entries similar to `runs` table is now avoided.