### PR TITLE
feat(backend/data): standardize extracted data

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -38,7 +38,6 @@ files = [
 ]
 
 [package.dependencies]
-exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
 
@@ -57,9 +56,6 @@ files = [
     {file = "async-lru-2.0.4.tar.gz", hash = "sha256:b8a59a5df60805ff63220b2a0c5b5393da5521b113cd5465a44eb037d81a5627"},
     {file = "async_lru-2.0.4-py3-none-any.whl", hash = "sha256:ff02944ce3c288c5be660c42dbcca0742b32c3b279d6dceda655190240b99224"},
 ]
-
-[package.dependencies]
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "authlib"
@@ -438,18 +434,29 @@ docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
 tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
-name = "exceptiongroup"
-version = "1.2.2"
-description = "Backport of PEP 654 (exception groups)"
+name = "damnit"
+version = "0.1.4"
+description = "The Data And Metadata iNspection Interactive Thing"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 files = [
-    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
-    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
+    {file = "damnit-0.1.4-py3-none-any.whl", hash = "sha256:db58140953e14ff87f7d807b2bfb6acce95e68ea70a49e439ce04217757cbcf8"},
+    {file = "damnit-0.1.4.tar.gz", hash = "sha256:0169552f7ef8f731662076cde3bb2bf1e4a280150b422563aa3ae7dc8ac4487d"},
 ]
 
+[package.dependencies]
+h5netcdf = "*"
+h5py = "*"
+orjson = "*"
+pandas = "*"
+plotly = "*"
+xarray = "*"
+
 [package.extras]
-test = ["pytest (>=6)"]
+backend = ["EXtra-data", "ipython", "kafka-python-ng", "kaleido", "matplotlib", "numpy", "pyyaml", "requests", "supervisor", "termcolor"]
+docs = ["mkdocs", "mkdocs-material", "mkdocstrings", "mkdocstrings-python", "pymdown-extensions"]
+gui = ["PyQt5", "PyQtWebEngine", "QScintilla (==2.13)", "adeqt", "mpl-pan-zoom", "mplcursors", "openpyxl", "pyflakes", "tabulate"]
+test = ["pillow", "pytest", "pytest-cov", "pytest-qt", "pytest-timeout", "pytest-venv", "pytest-xvfb", "testpath"]
 
 [[package]]
 name = "fastapi"
@@ -651,6 +658,24 @@ files = [
 ]
 
 [[package]]
+name = "h5netcdf"
+version = "1.4.1"
+description = "netCDF4 via h5py"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "h5netcdf-1.4.1-py3-none-any.whl", hash = "sha256:dd86c78ae69b92b16aa8a3c1ff3a14e7622571b5788dcf6d8b68569035bf71ce"},
+    {file = "h5netcdf-1.4.1.tar.gz", hash = "sha256:7c8401ab807ff37c9798edc90d99467595892e6c541a5d5abeb8f53aab5335fe"},
+]
+
+[package.dependencies]
+h5py = "*"
+packaging = "*"
+
+[package.extras]
+test = ["netCDF4", "pytest"]
+
+[[package]]
 name = "h5py"
 version = "3.12.1"
 description = "Read and write HDF5 files from Python"
@@ -795,28 +820,6 @@ files = [
 
 [package.extras]
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
-
-[[package]]
-name = "importlib-resources"
-version = "6.4.5"
-description = "Read resources from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_resources-6.4.5-py3-none-any.whl", hash = "sha256:ac29d5f956f01d5e4bb63102a5a19957f1b9175e45649977264a1416783bb717"},
-    {file = "importlib_resources-6.4.5.tar.gz", hash = "sha256:980862a1d16c9e147a59603677fa2aa5fd82b87f223b6cb870695bcfce830065"},
-]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "zipp (>=3.17)"]
-type = ["pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
@@ -1094,7 +1097,6 @@ files = [
 contourpy = ">=1.0.1"
 cycler = ">=0.10"
 fonttools = ">=4.22.0"
-importlib-resources = {version = ">=3.2.0", markers = "python_version < \"3.10\""}
 kiwisolver = ">=1.3.1"
 numpy = ">=1.23"
 packaging = ">=20.0"
@@ -1301,11 +1303,7 @@ files = [
 ]
 
 [package.dependencies]
-numpy = [
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
-    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
-    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
-]
+numpy = {version = ">=1.26.0", markers = "python_version >= \"3.12\""}
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
 tzdata = ">=2022.7"
@@ -1431,6 +1429,21 @@ mic = ["olefile"]
 tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
 typing = ["typing-extensions"]
 xmp = ["defusedxml"]
+
+[[package]]
+name = "plotly"
+version = "5.24.1"
+description = "An open-source, interactive data visualization library for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "plotly-5.24.1-py3-none-any.whl", hash = "sha256:f67073a1e637eb0dc3e46324d9d51e2fe76e9727c892dde64ddf1e1b51f29089"},
+    {file = "plotly-5.24.1.tar.gz", hash = "sha256:dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae"},
+]
+
+[package.dependencies]
+packaging = "*"
+tenacity = ">=6.2.0"
 
 [[package]]
 name = "pluggy"
@@ -1674,11 +1687,9 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -2074,7 +2085,6 @@ files = [
 
 [package.dependencies]
 anyio = ">=3.4.0,<5"
-typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart", "pyyaml"]
@@ -2138,15 +2148,19 @@ tests = ["freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "pytest-asyncio (>=
 typing = ["mypy (>=1.4)", "rich", "twisted"]
 
 [[package]]
-name = "tomli"
-version = "2.0.1"
-description = "A lil' TOML parser"
+name = "tenacity"
+version = "9.0.0"
+description = "Retry code until it succeeds"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+    {file = "tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539"},
+    {file = "tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b"},
 ]
+
+[package.extras]
+doc = ["reno", "sphinx"]
+test = ["pytest", "tornado (>=4.5)", "typeguard"]
 
 [[package]]
 name = "typer"
@@ -2222,7 +2236,6 @@ h11 = ">=0.8"
 httptools = {version = ">=0.5.0", optional = true, markers = "extra == \"standard\""}
 python-dotenv = {version = ">=0.13", optional = true, markers = "extra == \"standard\""}
 pyyaml = {version = ">=5.1", optional = true, markers = "extra == \"standard\""}
-typing-extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 uvloop = {version = ">=0.14.0,<0.15.0 || >0.15.0,<0.15.1 || >0.15.1", optional = true, markers = "(sys_platform != \"win32\" and sys_platform != \"cygwin\") and platform_python_implementation != \"PyPy\" and extra == \"standard\""}
 watchfiles = {version = ">=0.13", optional = true, markers = "extra == \"standard\""}
 websockets = {version = ">=10.4", optional = true, markers = "extra == \"standard\""}
@@ -2465,25 +2478,31 @@ files = [
 ]
 
 [[package]]
-name = "zipp"
-version = "3.20.2"
-description = "Backport of pathlib-compatible object wrapper for zip files"
+name = "xarray"
+version = "2024.11.0"
+description = "N-D labeled arrays and datasets in Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 files = [
-    {file = "zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350"},
-    {file = "zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29"},
+    {file = "xarray-2024.11.0-py3-none-any.whl", hash = "sha256:6ee94f63ddcbdd0cf3909d1177f78cdac756640279c0e32ae36819a89cdaba37"},
+    {file = "xarray-2024.11.0.tar.gz", hash = "sha256:1ccace44573ddb862e210ad3ec204210654d2c750bec11bbe7d842dfc298591f"},
 ]
 
+[package.dependencies]
+numpy = ">=1.24"
+packaging = ">=23.2"
+pandas = ">=2.1"
+
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
-type = ["pytest-mypy"]
+accel = ["bottleneck", "flox", "numba (>=0.54)", "numbagg", "opt_einsum", "scipy"]
+complete = ["xarray[accel,etc,io,parallel,viz]"]
+dev = ["hypothesis", "jinja2", "mypy", "pre-commit", "pytest", "pytest-cov", "pytest-env", "pytest-timeout", "pytest-xdist", "ruff", "sphinx", "sphinx_autosummary_accessors", "xarray[complete]"]
+etc = ["sparse"]
+io = ["cftime", "fsspec", "h5netcdf", "netCDF4", "pooch", "pydap", "scipy", "zarr"]
+parallel = ["dask[complete]"]
+viz = ["cartopy", "matplotlib", "nc-time-axis", "seaborn"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9"
-content-hash = "1b04d19cf36c5332efcd1946e0b7d0e6b9dc157f6908fdd6fccf392c0d2268f3"
+python-versions = "^3.12"
+content-hash = "229ddcf60d1540c45b0eee18028f6a3f98b52b52dca5333bc2a463eab7989ae9"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -33,6 +33,8 @@ ldap3 = "^2.9.1"
 requests = "^2.32.3"
 structlog = "^24.4.0"
 colorama = "^0.4.6"
+xarray = "^2024.11.0"
+damnit = "^0.1.4"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.2"

--- a/api/src/damnit_api/const.py
+++ b/api/src/damnit_api/const.py
@@ -5,11 +5,15 @@ DEFAULT_PROPOSAL = "2956"
 FILL_VALUE = "None"
 
 
-class Type(Enum):
+class DamnitType(Enum):
     NUMBER = "number"
     STRING = "string"
     BOOLEAN = "boolean"
+    TIMESTAMP = "timestamp"
+
     ARRAY = "array"
     IMAGE = "image"
     RGBA = "rgba"
-    TIMESTAMP = "timestamp"
+
+    PNG = "png"
+    DATASET = "dataset"

--- a/api/src/damnit_api/data.py
+++ b/api/src/damnit_api/data.py
@@ -1,0 +1,218 @@
+import io
+
+import numpy as np
+from PIL import Image
+import xarray as xr
+
+from damnit.api import Damnit, DataType
+
+from .const import DamnitType
+from .utils import b64image
+
+
+def get_extracted_data(proposal, run, variable):
+    var_data = Damnit(proposal)[run, variable]
+    type_hint = var_data.type_hint()
+    data = var_data.read()
+
+    # REMOVEME
+    if variable == "azimuthal_pump_diff_minus_ref":
+        data = np.random.randint(0, 255, size=data.shape)
+
+    dtype = get_damnit_type(data, type_hint=type_hint)
+    attrs = None
+    match type_hint:
+        case DataType.DataArray | None:
+            data = get_array(data)
+        case DataType.Image:
+            attrs = {"shape": list(data.shape[:2])}
+            data = get_png(data)
+            dtype = DamnitType.PNG
+        case _:
+            raise ValueError(f"Not supported: {type_hint}")
+
+    return standardize(data, name=variable, dtype=dtype.value, attrs=attrs)
+
+
+def get_png(data):
+    image_obj = Image.fromarray(data)
+
+    with io.BytesIO() as buffer:
+        image_obj.save(buffer, format="PNG")
+        image_str = b64image(buffer.getvalue())
+
+    return image_str
+
+
+def get_array(data):
+    array = to_dataarray(data)
+    array = downsample(array)
+
+    return with_attributes(array)
+
+
+# -----------------------------------------------------------------
+# Types
+
+
+def get_damnit_type(data, *, type_hint=None):
+    match type_hint:
+        case DataType.Image:
+            return DamnitType.RGBA
+        case DataType.Timestamp:
+            return DamnitType.TIMESTAMP
+        case None:
+            if np.isscalar(data):
+                if isinstance(data, str):
+                    return DamnitType.STRING
+                elif isinstance(data, bool):
+                    return DamnitType.BOOLEAN
+                elif isinstance(data, (int, float)):
+                    return DamnitType.NUMBER
+                else:
+                    raise ValueError("Not supported.")
+        case DataType.Dataset | DataType.PlotlyFigure:
+            raise ValueError("Not supported.")
+
+    if not isinstance(data, (xr.DataArray, np.ndarray)):
+        raise ValueError("Not supported.")
+
+    match data.ndim:
+        case 1:
+            return DamnitType.ARRAY
+        case 2:
+            return DamnitType.IMAGE
+        case _:
+            raise ValueError("Not supported.")
+
+
+# -----------------------------------------------------------------
+# DataArray
+
+
+def to_dataarray(data):
+    match type(data):
+        case np.ndarray:
+            # We need to squeeze the data first
+            # to set the right dimension names
+            array = xr.DataArray(data.squeeze())
+        case xr.DataArray:
+            array = data.squeeze(drop=True)
+        case _:
+            raise ValueError("Not supported")
+
+    array = rename_dims(array)
+    array = fill_coords(array)
+    return array
+
+
+def rename_dims(array):
+    match array.ndim:
+        case 1:
+            dims = ["index"]
+        case 2:
+            dims = ["y", "x"]
+        case _:
+            raise ValueError("Not supported")
+
+    renamed = {dim: dims[i] for i, dim in enumerate(array.dims) if dim == f"dim_{i}"}
+    if renamed:
+        array = array.rename(renamed)
+    return array
+
+
+def fill_coords(array):
+    missing = {
+        dim: np.arange(array.sizes[dim])
+        for dim in array.dims
+        if dim not in array.coords
+    }
+
+    if missing:
+        array = array.assign_coords(**missing)
+
+    return array
+
+
+def downsample(
+    data_array,
+    *,
+    max_bins_1d: int = 10_000,
+    max_bins_2d: int = 1_000,
+    min_ratio_2d: float = 0.05,
+):
+    match data_array.ndim:
+        case 1:
+            bins = [min(max_bins_1d, data_array.size)]
+
+            # Skip downsampling if the size is small
+            if bins[0] == data_array.size:
+                return data_array
+        case 2:
+            Ny, Nx = data_array.shape
+
+            # Skip downsampling if the sizes are small
+            if max(Ny, Nx) <= max_bins_2d:
+                return data_array
+
+            # Skip downsampling if the ratio is small
+            ratio = min(Ny, Nx) / max(Ny, Nx)
+            if ratio < min_ratio_2d:
+                return data_array
+
+            denom = max(Nx, Ny)
+            factor = max_bins_2d / denom
+            bins = [max(1, int(Ny * factor)), max(1, int(Nx * factor))]
+        case _:
+            raise RuntimeError("Downsampling is only supported for 1D or 2D arrays")
+
+    coords = {
+        d: np.linspace(
+            np.nanmin(data_array.coords[d]), np.nanmax(data_array.coords[d]), num=b
+        )
+        for d, b in zip(data_array.dims, bins)
+    }
+
+    return data_array.interp(**coords, method="linear")
+
+
+def with_attributes(array):
+    match array.ndim:
+        case 2:
+            vmin = np.nanquantile(array, 0.01, method="nearest")
+            vmax = np.nanquantile(array, 0.99, method="nearest")
+            array.attrs["colormap_range"] = [vmin, vmax]
+
+    array.attrs["shape"] = list(array.shape)
+
+    return array
+
+
+# -----------------------------------------------------------
+# Standardization
+
+
+def standardize(data, *, name="default", dtype=None, attrs=None):
+    """This uses the xarray.DataArray format, with added dtype."""
+    match type(data):
+        case xr.DataArray:
+            result = data.to_dict()
+            result["coords"] = {
+                dim: coord["data"] for dim, coord in result["coords"].items()
+            }
+        case _:
+            result = {
+                "data": data,
+                "attrs": {},
+            }
+
+    if attrs:
+        result["attrs"].update(attrs)
+
+    if not result.get("name"):
+        result["name"] = name
+
+    if dtype is not None:
+        result["dtype"] = dtype
+
+    return result

--- a/api/src/damnit_api/db.py
+++ b/api/src/damnit_api/db.py
@@ -17,8 +17,6 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
-from damnit_api.utils import get_run_data
-
 from .const import DEFAULT_PROPOSAL
 from .utils import Registry, create_map, find_proposal
 
@@ -125,24 +123,14 @@ async def async_latest_rows(
     return result.mappings().all()
 
 
-async def async_count(proposal, *, table: str, by="run"):
+async def async_column(proposal, *, table: str, name: str):
     table = await async_table(proposal, name=table)
-    selection = select(func.count(table.c.get(by)))
+    selection = select(table.c.get(name))
 
     async with get_session(proposal) as session:
         result = await session.execute(selection)
 
-    return result.scalar()
-
-
-# -----------------------------------------------------------------------------
-# Run data
-
-
-def get_extracted_data(proposal, run, variable):
-    root_path = DatabaseSessionManager(proposal).root_path
-    data_path = str(Path(root_path) / "extracted_data" / f"p{proposal}_r{run}.h5")
-    return get_run_data(data_path, variable)
+    return result.scalars().all()
 
 
 # -----------------------------------------------------------------------------

--- a/api/src/damnit_api/graphql/models.py
+++ b/api/src/damnit_api/graphql/models.py
@@ -14,7 +14,7 @@ import numpy as np
 import strawberry
 
 from ..const import DEFAULT_PROPOSAL
-from ..const import Type as DamnitType
+from ..const import DamnitType
 from ..utils import Registry, b64image, create_map, map_dtype
 
 T = TypeVar("T")

--- a/api/src/damnit_api/graphql/router.py
+++ b/api/src/damnit_api/graphql/router.py
@@ -1,3 +1,4 @@
+import numpy as np
 import orjson
 from strawberry.fastapi import GraphQLRouter
 from strawberry.http import GraphQLHTTPResponse
@@ -20,7 +21,11 @@ class Router(GraphQLRouter, metaclass=Singleton):
         )
 
     def encode_json(self, data: GraphQLHTTPResponse) -> bytes:
-        return orjson.dumps(data)
+        return orjson.dumps(
+            data,
+            default=lambda x: None if isinstance(x, float) and np.isnan(x) else x,
+            option=orjson.OPT_SERIALIZE_NUMPY,
+        )
 
 
 async def get_context():

--- a/api/src/damnit_api/utils.py
+++ b/api/src/damnit_api/utils.py
@@ -7,22 +7,22 @@ import h5py
 import numpy as np
 from scipy.ndimage import zoom
 
-from .const import Type
+from .const import DamnitType
 
 DEFAULT_ARRAY_NAME = "__xarray_dataarray_variable__"
 
 
 DTYPE_MAP = {
-    "bytes": Type.IMAGE,
-    "str": Type.STRING,
-    "bool_": Type.BOOLEAN,
+    "bytes": DamnitType.IMAGE,
+    "str": DamnitType.STRING,
+    "bool_": DamnitType.BOOLEAN,
 }
 
 
-def map_dtype(dtype, default=Type.STRING):
+def map_dtype(dtype, default=DamnitType.STRING):
     dtype = DTYPE_MAP.get(dtype.__name__)
     if not dtype:
-        dtype = Type.NUMBER if np.issubdtype(dtype, np.number) else default
+        dtype = DamnitType.NUMBER if np.issubdtype(dtype, np.number) else default
     return dtype
 
 
@@ -31,7 +31,7 @@ def map_dtype(dtype, default=Type.STRING):
 
 
 def b64image(bytes_):
-    return b64encode(bytes_).decode("utf-8")
+    return f"data:image/png;base64,{b64encode(bytes_).decode("utf-8")}"
 
 
 # -----------------------------------------------------------------------------

--- a/api/tests/test_data.py
+++ b/api/tests/test_data.py
@@ -1,0 +1,294 @@
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.testing import assert_array_equal
+import pytest
+import xarray as xr
+
+from damnit.api import DataType
+
+from damnit_api.data import (
+    get_damnit_type,
+    get_extracted_data,
+    standardize,
+    to_dataarray,
+)
+from damnit_api.const import DamnitType
+
+
+# ---- get_damnit_type -------------------------------------------------------
+
+
+@dataclass
+class TestData:
+    value: object
+    expected_type: DamnitType
+    type_hint: DataType | None = None
+
+
+scalars = [
+    TestData(value="foo", expected_type=DamnitType.STRING),
+    TestData(value=1234, expected_type=DamnitType.NUMBER),
+    TestData(value=False, expected_type=DamnitType.BOOLEAN),
+]
+images = [
+    TestData(
+        value=np.random.randint(0, 256, (2, 3, 4), dtype=np.uint8),
+        type_hint=DataType.Image,
+        expected_type=DamnitType.RGBA,
+    ),
+]
+ndarrays = [
+    TestData(
+        value=np.random.rand(10),
+        expected_type=DamnitType.ARRAY,
+    ),
+    TestData(
+        value=np.random.rand(4, 3),
+        expected_type=DamnitType.IMAGE,
+    ),
+]
+dataarrays = [
+    TestData(
+        xr.DataArray(data.value),
+        type_hint=DataType.DataArray,
+        expected_type=data.expected_type,
+    )
+    for data in ndarrays
+]
+datasets = [
+    TestData(
+        value=xr.Dataset(
+            {
+                "a": ("x", np.random.rand(10)),
+                "b": ("x", np.random.rand(10)),
+            },
+            coords={"x": np.arange(10)},
+        ),
+        type_hint=DataType.Dataset,
+        expected_type=DamnitType.DATASET,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "data",
+    scalars + images + ndarrays + dataarrays,
+)
+def test_get_damnit_type_valid(data):
+    assert get_damnit_type(data.value, type_hint=data.type_hint) is data.expected_type
+
+
+@pytest.mark.parametrize(
+    "data",
+    datasets,
+)
+def test_get_damnit_type_unsupported(data):
+    with pytest.raises(ValueError):
+        get_damnit_type(data.value, type_hint=data.type_hint)
+
+
+# ---- to_dataarray ----------------------------------------------------------
+
+
+def test_to_dataarray_1d_ndarray():
+    data = np.random.rand(10)
+    assert to_dataarray(data).equals(
+        xr.DataArray(data, dims=["index"], coords={"index": np.arange(data.shape[0])})
+    )
+
+
+def test_to_dataarray_2d_ndarray():
+    data = np.random.rand(4, 3)
+    assert to_dataarray(data).equals(
+        xr.DataArray(
+            data,
+            dims=["y", "x"],
+            coords={"y": np.arange(data.shape[0]), "x": np.arange(data.shape[1])},
+        )
+    )
+
+
+def test_to_dataarray_1d_dataarray_no_coords():
+    data = xr.DataArray(
+        np.random.rand(10),
+    )
+    assert to_dataarray(data).equals(
+        xr.DataArray(
+            data.values,
+            dims=["index"],
+            coords={"index": np.arange(data.shape[0])},
+        )
+    )
+
+
+def test_to_dataarray_1d_dataarray_with_coords():
+    data = xr.DataArray(
+        np.random.rand(4),
+        dims=["trains"],
+        coords={"trains": [1000, 1001, 1002, 1003]},
+    )
+    assert to_dataarray(data).equals(data)  # No change
+
+
+def test_to_dataarray_2d_dataarray_no_coords():
+    data = xr.DataArray(
+        np.random.rand(4, 3),
+    )
+    assert to_dataarray(data).equals(
+        xr.DataArray(
+            data.values,
+            dims=["y", "x"],
+            coords={
+                "y": np.arange(data.shape[0]),
+                "x": np.arange(data.shape[1]),
+            },
+        )
+    )
+
+
+def test_to_dataarray_2d_dataarray_with_coords():
+    data = xr.DataArray(
+        np.random.rand(4, 3),
+        dims=["trains", "pulses"],
+        coords={
+            "trains": [1000, 1001, 1002, 1003],
+            "pulses": [
+                0,
+                1,
+                2,
+            ],
+        },
+    )
+    assert to_dataarray(data).equals(data)  # No change
+
+
+@pytest.mark.parametrize("data", scalars + datasets)
+def test_to_data_array_unsupported(data):
+    with pytest.raises(ValueError):
+        to_dataarray(data)
+
+
+# ---- standardize -----------------------------------------------------------
+
+
+def test_standardize_dataarray():
+    name = "some_image"
+    dtype = DamnitType.IMAGE
+    data = xr.DataArray(
+        data=np.random.rand(4, 3),
+        name=name,
+        dims=["y", "x"],
+        coords={
+            "y": [0, 1, 2, 3],
+            "x": [
+                0,
+                1,
+                2,
+            ],
+        },
+        attrs={},
+    )
+
+    actual = standardize(data, dtype=dtype.value)
+    assert actual["name"] == name
+    assert actual["dtype"] == dtype.value
+    assert actual["data"] == data.data.tolist()
+    assert actual["dims"] == data.dims
+    assert_coords(actual["coords"], data.coords)
+    assert actual["attrs"] == data.attrs
+
+    # assert actual == expected
+
+
+def test_standardize_png():
+    name = "some_png"
+    dtype = DamnitType.PNG
+    data = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAABQUlEQVR4nAE2Acn+ARvURClMomT2KO"
+
+    assert standardize(data, name=name, dtype=dtype.value) == {
+        "data": data,
+        "name": name,
+        "dtype": dtype.value,
+        "attrs": {},
+    }
+
+
+# ---- standardize -----------------------------------------------------------
+
+DAMNIT_CLASS_PATH = "damnit_api.data.Damnit"
+
+
+def mock_damnit_class(mocker, *, data, type_hint):
+    mock_variable = mocker.Mock(
+        type_hint=mocker.Mock(return_value=type_hint),
+        read=mocker.Mock(return_value=data),
+    )
+    mock_damnit_cls = mocker.patch(DAMNIT_CLASS_PATH)
+    mock_damnit_cls.return_value.__getitem__.return_value = mock_variable
+    return mock_damnit_cls
+
+
+def test_get_extracted_data_ndarray(mocker):
+    name = "some_array"
+    dtype = DamnitType.ARRAY
+    data = np.random.rand(4)
+
+    mock_damnit_class(mocker, data=data, type_hint=None)
+    actual = get_extracted_data(proposal=1234, run=1, variable=name)
+
+    assert actual == {
+        "name": name,
+        "data": data.tolist(),
+        "attrs": {"shape": list(data.shape)},
+        "dims": ("index",),
+        "coords": {"index": [0, 1, 2, 3]},
+        "dtype": dtype.value,
+    }
+
+
+def test_get_extracted_data_dataarray(mocker):
+    name = "some_array"
+    dtype = DamnitType.ARRAY
+    data = xr.DataArray(
+        np.random.rand(4),
+        dims=["trains"],
+        coords={"trains": [1000, 1001, 1002, 1003]},
+    )
+
+    mock_damnit_class(mocker, data=data, type_hint=DataType.DataArray)
+    actual = get_extracted_data(proposal=1234, run=1, variable=name)
+
+    assert actual["name"] == name
+    assert actual["dtype"] == dtype.value
+    assert actual["data"] == data.data.tolist()
+    assert actual["attrs"] == {**data.attrs, "shape": list(data.shape)}
+
+    assert actual["dims"] == data.dims
+    assert_coords(actual["coords"], data.coords)
+
+
+def test_get_extracted_data_png(mocker):
+    name = "some_png"
+    dtype = DamnitType.PNG  # because we convert RGBA array to PNG string
+    data = np.random.randint(0, 256, (2, 3, 4), dtype=np.uint8)
+
+    mock_damnit_class(mocker, data=data, type_hint=DataType.Image)
+    actual = get_extracted_data(proposal=1234, run=1, variable=name)
+
+    assert actual["name"] == name
+    assert actual["dtype"] == dtype.value
+    assert isinstance(actual["data"], str)
+    assert actual["attrs"] == {"shape": list(data.shape[:2])}
+
+
+# ---- helpers -----------------------------------------------------------
+
+
+def assert_coords(actual, expected):
+    assert len(actual) == len(expected)
+    for (actual_dim, actual_coord), (expected_dim, expected_coord) in zip(
+        actual.items(), expected.items()
+    ):
+        assert actual_dim == expected_dim
+        assert_array_equal(actual_coord, expected_coord)


### PR DESCRIPTION
This PR aims to standardize the (extracted) data sent to the frontend for visualization, such that they can be handled the similar way. The following supported data types are:

- 1D arrays: `xr.DataArray` and `np.ndarray`
- 2D images: `xr.DataArray` and `np.ndarray`
- RGBA images: `np.ndarray`

To improve usability and visualization, the following metadata is included:
- Coordinates: preserves spatial integrity, especially useful with xarray and downsampling.
- Colormap range: ensures 2D images display consistently with the generated thumbnails.
- Shape: helps define widget geometry on the frontend.

The following performance improvements are also included as they are somehow related:
- Downsampling: helps send large data over the network
- RGBA Conversion: converts images to base64-encoded PNG strings

Other data types (e.g., `xr.Dataset`) are currently excluded.