### PR TITLE
feat(plotting): enable plotting of data from non-empty table cells

### DIFF
--- a/api/src/damnit_api/const.py
+++ b/api/src/damnit_api/const.py
@@ -6,6 +6,7 @@ FILL_VALUE = "None"
 
 
 class DamnitType(Enum):
+    NONE = "none"
     NUMBER = "number"
     STRING = "string"
     BOOLEAN = "boolean"

--- a/frontend/src/redux/slices/extractedData.ts
+++ b/frontend/src/redux/slices/extractedData.ts
@@ -35,15 +35,13 @@ const slice = createSlice({
     builder.addCase(getExtractedVariable.fulfilled, (state, action) => {
       // TODO: Add pending and rejected
       const { run, variable, data, ...metadata } = action.payload
-      if (!isEmpty(data)) {
-        state.data = {
-          ...state.data,
-          [run]: { ...(state.data[run] ?? {}), [variable]: data },
-        }
-        state.metadata = {
-          ...state.metadata,
-          [run]: { ...(state.metadata[run] ?? {}), [variable]: metadata },
-        }
+      state.data = {
+        ...state.data,
+        [run]: { ...(state.data[run] ?? {}), [variable]: data },
+      }
+      state.metadata = {
+        ...state.metadata,
+        [run]: { ...(state.metadata[run] ?? {}), [variable]: metadata },
       }
     })
   },

--- a/frontend/src/utils/plots.ts
+++ b/frontend/src/utils/plots.ts
@@ -5,5 +5,6 @@ export const canPlotSummary = (data, dtype) => {
 }
 
 export const canPlotData = (data, dtype) => {
-  return [DTYPES.number, DTYPES.image].includes(dtype)
+  // TODO: Use extracted data type from the database
+  return data != null
 }


### PR DESCRIPTION
This PR adds support for plotting data from all non-empty table cells, even if the extracted data is not plottable in the frontend. This covers:

<details>
<summary>1. Scalars (e.g., strings, numbers, booleans).</summary>

![chrome_sjQlyx1Ba7](https://github.com/user-attachments/assets/9ba4207e-d71e-4103-b3a4-1a5da44f8057)

</details>

<details>
<summary>1. Unsupported types (e.g., xr.Dataset, PlotlyFigure)</summary>

![chrome_06w34YqxQ8](https://github.com/user-attachments/assets/326454a9-eec7-4366-aa15-7406fe9ee6b4)

</details>

As future improvement, the frontend should detect and display whether cells are plottable at a glance, and disable the plot option for unsupported values. This would most likely require the `db.type_hint()` metadata on the database.