### PR TITLE
style: run `ruff` on API tests

### DIFF
--- a/api/src/damnit_api/main.py
+++ b/api/src/damnit_api/main.py
@@ -83,7 +83,8 @@ if __name__ == "__main__":
 
     if settings.uvicorn.ssl_cert_reqs != 2:
         logger.warning(
-            "Not configured to require mTLS. This is not recommended for production."
+            "Not configured to require mTLS. "
+            "This is not recommended for production."
         )
 
     uvicorn.run(

--- a/api/tests/graphql/test_models.py
+++ b/api/tests/graphql/test_models.py
@@ -1,6 +1,5 @@
 from damnit_api.graphql.models import (
     DamnitTable,
-    DamnitType,
     get_model,
     update_model,
 )

--- a/api/tests/graphql/test_queries.py
+++ b/api/tests/graphql/test_queries.py
@@ -1,32 +1,32 @@
 import pytest
-import pytest_asyncio
 
 from damnit_api.graphql.models import DamnitRun
 
 from .const import EXAMPLE_VALUES, EXAMPLE_VARIABLES, KNOWN_VALUES, RUNS
 
-
 # TODO: Test with actual values without mocking the fetch functions
 
 
-@pytest_asyncio.fixture
-async def mocked_fetch_variables(mocker):
-    mocker.patch(
+@pytest.fixture
+def mocked_fetch_variables(mocker):
+    return mocker.patch(
         "damnit_api.graphql.queries.fetch_variables",
         return_value=[EXAMPLE_VALUES],
     )
 
 
-@pytest_asyncio.fixture
-async def mocked_fetch_info(mocker):
-    mocker.patch(
+@pytest.fixture
+def mocked_fetch_info(mocker):
+    return mocker.patch(
         "damnit_api.graphql.queries.fetch_info",
         return_value=[KNOWN_VALUES],
     )
 
 
 @pytest.mark.asyncio
-async def test_runs_query(graphql_schema, mocked_fetch_variables, mocked_fetch_info):
+async def test_runs_query(
+    graphql_schema, mocked_fetch_variables, mocked_fetch_info
+):
     query = """
         query TableDataQuery($per_page: Int = 2) {
           runs(database: {proposal: "1234"}, per_page: $per_page) {

--- a/api/tests/graphql/utils.py
+++ b/api/tests/graphql/utils.py
@@ -48,4 +48,4 @@ def assert_stype(stype, variables):
             assert type_.__origin__ is KnownVariable
         else:
             assert prop in variables
-            assert type_ is Optional[DamnitVariable]
+            assert type_ is Optional[DamnitVariable]  # noqa: UP007


### PR DESCRIPTION
Quick follow up on the codebase cleanup: for the tests this time.