### PR TITLE
fix(api/models): make `start_time` and `added_at` nullable

### DIFF
--- a/api/src/damnit_api/graphql/models.py
+++ b/api/src/damnit_api/graphql/models.py
@@ -78,8 +78,8 @@ class DamnitVariable(BaseVariable):
 class DamnitRun:
     proposal: KnownVariable[int]
     run: KnownVariable[int]
-    start_time: KnownVariable[Timestamp]
-    added_at: KnownVariable[Timestamp]
+    start_time: KnownVariable[Timestamp] | None
+    added_at: KnownVariable[Timestamp] | None
 
     @classmethod
     def from_db(cls, entry):


### PR DESCRIPTION
User-added rows (or runs) initially do not have timestamps. This PR aligns with this behavior.