### PR TITLE
fix(frontend/metadata): reset metadata on proposal number change

### DIFF
--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -11,7 +11,7 @@ import LoadingBar, { showLoading } from "react-redux-loading-bar"
 
 import { useProposal } from "./use-proposal"
 import { resetExtractedData } from "../data/extracted"
-import { setProposalPending } from "../data/metadata"
+import { resetMetadata, setProposalPending } from "../data/metadata"
 import { resetTable as resetTableData } from "../data/table"
 import Dashboard from "../features/dashboard"
 import {
@@ -41,6 +41,7 @@ function ProposalWrapper({ children }: PropsWithChildren) {
       dispatch(resetTableView())
       dispatch(resetExtractedData())
       dispatch(resetPlots())
+      dispatch(resetMetadata())
     }
   }, [proposal_number, dispatch])
 

--- a/frontend/src/data/metadata/index.ts
+++ b/frontend/src/data/metadata/index.ts
@@ -1,6 +1,7 @@
 export { metadataApi, useGetProposalQuery } from "./metadata.api"
 export {
   default as metadataReducer,
+  resetMetadata,
   setProposalPending,
   setProposalSuccess,
   setProposalNotFound,

--- a/frontend/src/data/metadata/metadata.slice.ts
+++ b/frontend/src/data/metadata/metadata.slice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit"
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 interface Proposal {
   value: string
@@ -12,16 +12,17 @@ interface State {
 
 const initialState: State = {
   proposal: {
-    value: "",
+    value: '',
     loading: false,
     notFound: false,
   },
 }
 
 const slice = createSlice({
-  name: "metadata",
+  name: 'metadata',
   initialState,
   reducers: {
+    reset: () => initialState,
     setProposalPending(state, action: PayloadAction<string>) {
       state.proposal = {
         ...initialState.proposal,
@@ -40,5 +41,9 @@ const slice = createSlice({
 })
 
 export default slice.reducer
-export const { setProposalPending, setProposalSuccess, setProposalNotFound } =
-  slice.actions
+export const {
+  setProposalPending,
+  setProposalSuccess,
+  setProposalNotFound,
+  reset: resetMetadata,
+} = slice.actions


### PR DESCRIPTION
More fixes on race conditions when proposal numbers have changed. We reset the metadata gracefully on change.