### PR TITLE
Feat/tags backend support

### DIFF
--- a/api/src/damnit_api/db.py
+++ b/api/src/damnit_api/db.py
@@ -136,6 +136,18 @@ async def async_column(proposal, *, table: str, name: str):
     return result.scalars().all()
 
 
+async def async_all_tags(proposal):
+    tags_table = await async_table(proposal, name="tags")
+    selection = select(
+        tags_table.c.id,
+        tags_table.c.name,
+    )
+    async with get_session(proposal) as session:
+        result = await session.execute(selection)
+
+    return result.mappings().all()
+
+
 # -----------------------------------------------------------------------------
 # Etc.
 

--- a/api/src/damnit_api/graphql/bootstrap.py
+++ b/api/src/damnit_api/graphql/bootstrap.py
@@ -13,6 +13,9 @@ async def bootstrap(proposal=db.DEFAULT_PROPOSAL):
 
     model = models.get_model(proposal)
 
+    tags = await db.async_all_tags(proposal)
+    model.tags = [models.DamnitTag(**tag) for tag in tags]
+
     variables = await db.async_variables(proposal)
     model.update(variables)
 

--- a/api/src/damnit_api/graphql/models.py
+++ b/api/src/damnit_api/graphql/models.py
@@ -58,10 +58,17 @@ Timestamp = strawberry.scalar(
 )
 
 
+@strawberry.type
+class DamnitTag:
+    id: int
+    name: Any | None
+
+
 @strawberry.interface
 class BaseVariable:
     name: str
     dtype: str
+    tag_ids: list[int] | None
 
 
 @strawberry.type
@@ -73,10 +80,6 @@ class KnownVariable(Generic[T], BaseVariable):
 class DamnitVariable(BaseVariable):
     value: Any | None
 
-@strawberry.type
-class DamnitTag:
-    id: int
-    name: Any | None
 
 @strawberry.interface
 class DamnitRun:

--- a/api/src/damnit_api/graphql/models.py
+++ b/api/src/damnit_api/graphql/models.py
@@ -73,6 +73,10 @@ class KnownVariable(Generic[T], BaseVariable):
 class DamnitVariable(BaseVariable):
     value: Any | None
 
+@strawberry.type
+class DamnitTag:
+    id: int
+    name: Any | None
 
 @strawberry.interface
 class DamnitRun:
@@ -172,6 +176,7 @@ class DamnitTable(metaclass=Registry):
         self.variables = DamnitRun.known_variables()
         self.stype = self._create_stype()
         self.runs = []
+        self.tags = []
 
     def update(self, variables=None, timestamp: float | None = None):
         """We update the strawberry type and the schema here"""

--- a/api/src/damnit_api/graphql/mutations.py
+++ b/api/src/damnit_api/graphql/mutations.py
@@ -20,5 +20,6 @@ class Mutation:
             "runs": model.runs,
             "variables": model.variables,
             "timestamp": model.timestamp * 1000,  # deserialize to JS
+            "tags": model.tags,
         }
         return {"metadata": metadata}

--- a/api/src/damnit_api/graphql/queries.py
+++ b/api/src/damnit_api/graphql/queries.py
@@ -121,6 +121,7 @@ class Query:
             "runs": model.runs,
             "variables": model.variables,
             "timestamp": model.timestamp * 1000,  # deserialize to JS
+            "tags": model.tags,
         }
 
     @strawberry.field


### PR DESCRIPTION
Adds support for the the Tags to be tracked from the graphql query. 

## Expected behaviour  

Expected response from

```graphql

mutation RefreshProposal ($database : String = "8836") {
  refresh(database : {proposal : $database})
  
}
```

would be

```json
{
  "data": {
    "refresh": {
      "metadata": {
        "runs": [...],
        "variables": { 
         ...
          "run_type": {
            "name": "run_type",
            "title": "Run Type",
            "tag_ids": [
              1,
              2
            ]
          } 
         ...
        },
        "timestamp": 1755849673690.313,
        "tags": [
          {
            "id": 1,
            "name": "Metadata"
          } ...
        ]
      }
    }
  }
}


## Summary

- Add tag_ids to variables (db.async_variables) and return top-level tags (db.async_all_tags).
- Populate model.tags in graphql.bootstrap.
- Handle missing tables (NoSuchTableError) — fall back to empty lists.