### PR TITLE
fix(api/tests): resolve optional Strawberry types by getting the type origin twice

### DIFF
--- a/api/src/damnit_api/graphql/models.py
+++ b/api/src/damnit_api/graphql/models.py
@@ -5,16 +5,13 @@ from typing import (
     NewType,
     Optional,
     TypeVar,
-    Union,
-    get_args,
-    get_origin,
 )
 
 import numpy as np
 import strawberry
 
 from ..const import DEFAULT_PROPOSAL, DamnitType
-from ..utils import Registry, b64image, create_map, map_dtype
+from ..utils import Registry, b64image, create_map, get_type, map_dtype
 
 T = TypeVar("T")
 
@@ -93,7 +90,7 @@ class DamnitRun:
                 variables[name] = None
                 continue
 
-            klass = cls.get_klass(klass)
+            klass = get_type(klass)
             dtype = cls.get_dtype(value=entry[name], klass=klass)
             value = serialize(entry[name], dtype=dtype)
 
@@ -149,14 +146,6 @@ class DamnitRun:
         else:
             dtype = map_dtype(type(value))
         return dtype
-
-    @staticmethod
-    def get_klass(klass):
-        if get_origin(klass) is Union:
-            # Optional type hint
-            return get_args(klass)[0]
-
-        return klass
 
 
 class DamnitTable(metaclass=Registry):

--- a/api/src/damnit_api/utils.py
+++ b/api/src/damnit_api/utils.py
@@ -2,7 +2,7 @@ import os.path as osp
 from abc import ABCMeta
 from base64 import b64encode
 from glob import iglob
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Union, get_args, get_origin
 
 import numpy as np
 
@@ -110,3 +110,11 @@ def create_map(
     key,
 ):
     return {obj[key]: {str(k): v for k, v in obj.items()} for obj in lst}
+
+
+def get_type(type_):
+    if get_origin(type_) is Union:
+        # Optional type hint
+        return get_args(type_)[0]
+
+    return type_

--- a/api/tests/graphql/utils.py
+++ b/api/tests/graphql/utils.py
@@ -1,10 +1,11 @@
-from typing import Optional
+from typing import Optional, get_origin
 
 from damnit_api.graphql.models import (
     DamnitRun,
     DamnitVariable,
     KnownVariable,
 )
+from damnit_api.utils import get_type
 
 from .const import KNOWN_DTYPES
 
@@ -45,7 +46,7 @@ def assert_stype(stype, variables):
     assert issubclass(stype, DamnitRun)
     for prop, type_ in stype.__annotations__.items():
         if prop in KNOWN_DTYPES:
-            assert type_.__origin__ is KnownVariable
+            assert get_origin(get_type(type_)) is KnownVariable
         else:
             assert prop in variables
             assert type_ is Optional[DamnitVariable]  # noqa: UP007


### PR DESCRIPTION
The API test have started to fail on this [PR](https://github.com/European-XFEL/DAMNIT-web/pull/100) as we have introduced optional `KnownVariable`s, which are not considered in the tests. This PR aims to fixes that.

Thanks for spotting this, @matheuscteo!