### PR TITLE
fix(frontend): use base URL for proxied endpoints

### DIFF
--- a/frontend/src/auth/auth.thunks.ts
+++ b/frontend/src/auth/auth.thunks.ts
@@ -1,6 +1,6 @@
 import { authApi } from './auth.api'
 
-import { FULL_URL } from '../constants'
+import { HTTP_URL } from '../constants'
 import { resetExtractedData } from '../data/extracted'
 import { resetTable as resetTableData } from '../data/table'
 import { resetTable as resetTableView } from '../features/table'
@@ -9,11 +9,11 @@ import { AppThunk } from '../redux'
 import { history } from '../routes'
 
 export const login = (): AppThunk => (_) => {
-  window.location.href = `${FULL_URL}oauth/login?redirect_uri=${FULL_URL}home`
+  window.location.href = `${HTTP_URL}oauth/login?redirect_uri=${HTTP_URL}home`
 }
 
 export const logout = (): AppThunk => (dispatch) => {
-  fetch(`${FULL_URL}oauth/logout?redirect_uri=${FULL_URL}logged-out`, {
+  fetch(`${HTTP_URL}oauth/logout?redirect_uri=${HTTP_URL}logged-out`, {
     method: 'GET',
     credentials: 'include', // Include cookies in the request
   })

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,6 +1,9 @@
 /// <reference types="vite/client" />
-export const BASE_URL = import.meta.env.BASE_URL
-export const FULL_URL = window.location.origin + BASE_URL
+export const BASE_URL = import.meta.env.VITE_BASE_URL
+export const HTTP_URL = window.location.origin + BASE_URL
+
+const wsProtocol = window.location.origin.startsWith('https') ? 'wss' : 'ws'
+export const WS_URL = `${wsProtocol}://${window.location.host}${BASE_URL}graphql`
 
 export const EMPTY_VALUE = 'None'
 export const VARIABLES = {

--- a/frontend/src/graphql/apollo.ts
+++ b/frontend/src/graphql/apollo.ts
@@ -21,7 +21,7 @@ import { getMainDefinition } from '@apollo/client/utilities'
 
 import { createClient } from 'graphql-ws'
 
-import { BASE_URL } from '../constants'
+import { BASE_URL, WS_URL } from '../constants'
 import { DEFERRED_TABLE_DATA_QUERY_NAME } from '../data/table'
 
 const removeTypenameLink = removeTypenameFromVariables({
@@ -110,11 +110,9 @@ const createPriorityLink = (maxActive = 3) => {
 
 const priorityLink = createPriorityLink(1)
 
-const wsProtocol = window.location.origin.startsWith('https') ? 'wss' : 'ws'
-const wsUri = `${wsProtocol}://${window.location.host}/graphql`
 const wsLink = new GraphQLWsLink(
   createClient({
-    url: wsUri,
+    url: WS_URL,
     shouldRetry: () => true,
   })
 )


### PR DESCRIPTION
This PR aims to enable the use of base URL especially for proxied endpoints. We now supply `VITE_BASE_URL` on the environment variables to resolve the proxies and and to resolve related URLs within the codebase. This implied that we should refrain using the default Vite `--base` argument at all.

FYI @RobertRosca 