### PR TITLE
feat(frontend/graphql): update frontend runs query to flat variable model

### DIFF
--- a/frontend/apps/demo/src/mocks/handlers.ts
+++ b/frontend/apps/demo/src/mocks/handlers.ts
@@ -91,18 +91,23 @@ function getMetadata(meta: Meta) {
   }
 }
 
-const gqlHandlers = [
-  api.mutation('RefreshMutation', async ({ variables }) => {
-    const { meta } = await fetchRuns(variables.proposal)
+async function buildTableData(proposal: string, names?: string[] | null) {
+  const { data } = await fetchRuns(proposal)
 
-    return HttpResponse.json({
-      data: {
-        refresh: {
-          metadata: getMetadata(meta),
-        },
-      },
-    })
-  }),
+  return {
+    runs: data.map((run) => ({
+      variables: Object.entries(run.variables)
+        .filter(([name]) => names == null || names.includes(name))
+        .map(([name, variable]) => ({
+          name,
+          value: variable.value,
+          dtype: variable.dtype,
+        })),
+    })),
+  }
+}
+
+const gqlHandlers = [
   api.query('TableMetadataQuery', async ({ variables }) => {
     const { meta } = await fetchRuns(variables.proposal)
 
@@ -113,16 +118,16 @@ const gqlHandlers = [
     })
   }),
   api.query('TableDataQuery', async ({ variables }) => {
-    const { data } = await fetchRuns(variables.proposal)
-
-    return HttpResponse.json({
-      data: {
-        runs: data.map((run) => ({
-          ...run.variables,
-          __typename: variables.proposal,
-        })),
-      },
-    })
+    const data = await buildTableData(variables.proposal, variables.names)
+    return HttpResponse.json({ data })
+  }),
+  api.query('LightweightTableDataQuery', async ({ variables }) => {
+    const data = await buildTableData(variables.proposal, variables.names)
+    return HttpResponse.json({ data })
+  }),
+  api.query('DeferredTableDataQuery', async ({ variables }) => {
+    const data = await buildTableData(variables.proposal, variables.names)
+    return HttpResponse.json({ data })
   }),
   api.query('ExtractedDataQuery', async ({ variables }) => {
     const data = await fetchData({

--- a/frontend/packages/ui/src/data/table/index.ts
+++ b/frontend/packages/ui/src/data/table/index.ts
@@ -11,6 +11,6 @@ export {
   updateTable,
 } from './table-data.slice'
 export {
-  REFRESH_MUTATION,
+  TABLE_METADATA_QUERY,
   LATEST_DATA_SUBSCRIPTION,
 } from './table-data.services'

--- a/frontend/packages/ui/src/data/table/table-data.services.ts
+++ b/frontend/packages/ui/src/data/table/table-data.services.ts
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { stripTypename } from '@apollo/client/utilities'
 
 import {
   DEFERRED_TABLE_DATA_QUERY_NAME,
@@ -14,14 +13,8 @@ import {
   type TableMetadataOptions,
 } from './table-data.types'
 import { client } from '../../graphql/apollo'
-import { type WithTypeName } from '../../types'
+import { type VariableDataItem, type VariableValue } from '../../types'
 import { isEmpty } from '../../utils/helpers'
-
-const NUMBER_RE = /^-?\d+(\.\d+)?$/
-
-function formatProposalName(proposal: string) {
-  return NUMBER_RE.test(proposal) ? `p${proposal}` : proposal
-}
 
 /*
  * -----------------------------
@@ -29,50 +22,100 @@ function formatProposalName(proposal: string) {
  * -----------------------------
  */
 
-const get_table_data_query = (
-  type: string,
-  fields: string[] = [],
-  lightweight = false,
-  deferred = false
-) => {
-  return gql`
-    query ${
-      deferred ? DEFERRED_TABLE_DATA_QUERY_NAME : TABLE_DATA_QUERY_NAME
-    }($proposal: String, $page: Int, $per_page: Int) {
-      runs(database: { proposal: $proposal }, page: $page, per_page: $per_page) ${
-        lightweight ? '@lightweight' : ''
-      } {
-        ... on ${type} {
-          ${fields.map((field) => `${field} { value dtype }`).join(' ')}
-        }
+const buildTableDataQuery = (
+  operationName: string,
+  lightweight: boolean
+) => gql`
+  query ${operationName}(
+    $proposal: String
+    $page: Int
+    $per_page: Int
+    $names: [String!]
+  ) {
+    runs(
+      database: { proposal: $proposal }
+      page: $page
+      per_page: $per_page
+    ) ${lightweight ? '@lightweight' : ''} {
+      variables(names: $names) {
+        name
+        value
+        dtype
       }
     }
-  `
+  }
+`
+
+const TABLE_DATA_QUERY = buildTableDataQuery(TABLE_DATA_QUERY_NAME, false)
+const LIGHTWEIGHT_TABLE_DATA_QUERY = buildTableDataQuery(
+  `Lightweight${TABLE_DATA_QUERY_NAME}`,
+  true
+)
+const DEFERRED_TABLE_DATA_QUERY = buildTableDataQuery(
+  DEFERRED_TABLE_DATA_QUERY_NAME,
+  false
+)
+
+type DamnitVariable = {
+  name: string
+  value: VariableValue
+  dtype: string
 }
 
-async function getTableData(
-  fields: string[],
-  options: TableDataOptions
-): Promise<TableData> {
+type DamnitRun = {
+  variables: DamnitVariable[]
+}
+
+export function flattenRuns(runs: DamnitRun[]): TableData {
+  const table: TableData = {}
+
+  for (const run of runs) {
+    const runVariable = run.variables.find((v) => v.name === 'run')
+    if (runVariable === undefined || runVariable.value == null) {
+      continue
+    }
+
+    const row: Record<string, VariableDataItem> = {}
+    for (const variable of run.variables) {
+      row[variable.name] = {
+        value: variable.value,
+        dtype: variable.dtype,
+      }
+    }
+
+    table[String(runVariable.value)] = row
+  }
+
+  return table
+}
+
+function pickTableDataQuery(lightweight: boolean, deferred: boolean) {
+  if (deferred) {
+    return DEFERRED_TABLE_DATA_QUERY
+  }
+  if (lightweight) {
+    return LIGHTWEIGHT_TABLE_DATA_QUERY
+  }
+  return TABLE_DATA_QUERY
+}
+
+async function getTableData(options: TableDataOptions): Promise<TableData> {
   const {
     proposal,
     page = 1,
     pageSize = 10,
     lightweight = false,
     deferred = false,
+    variables,
   } = options
 
   const { data } = await client.query({
-    query: get_table_data_query(
-      formatProposalName(proposal),
-      fields,
-      lightweight,
-      deferred
-    ),
+    query: pickTableDataQuery(lightweight, deferred),
     variables: {
       proposal: String(proposal),
       page,
       per_page: pageSize,
+      names: variables,
     },
   })
 
@@ -80,11 +123,7 @@ async function getTableData(
     return {}
   }
 
-  return Object.fromEntries(
-    data.runs.map((run: WithTypeName<TableData>) => {
-      return [run.run.value, stripTypename(run)]
-    })
-  )
+  return flattenRuns(data.runs as DamnitRun[])
 }
 
 /*
@@ -93,7 +132,7 @@ async function getTableData(
  * -----------------------------
  */
 
-const TABLE_METADATA_QUERY = gql`
+export const TABLE_METADATA_QUERY = gql`
   query TableMetadataQuery($proposal: String) {
     metadata(database: { proposal: $proposal })
   }
@@ -123,25 +162,10 @@ async function getTable({
   ...options
 }: TableDataOptions | TableMetadataOptions): Promise<TableInfo> {
   const metadata: TableMetadata = await getTableMetadata({ proposal })
-  const data = await getTableData(Object.keys(metadata.variables), {
-    proposal,
-    ...options,
-  })
+  const data = await getTableData({ proposal, ...options })
 
   return { data, metadata }
 }
-
-/*
- * -----------------------------
- *   Mutation: refresh
- * -----------------------------
- */
-
-export const REFRESH_MUTATION = gql`
-  mutation RefreshMutation($proposal: String) {
-    refresh(database: { proposal: $proposal })
-  }
-`
 
 /*
  * -----------------------------

--- a/frontend/packages/ui/src/data/table/table-data.slice.ts
+++ b/frontend/packages/ui/src/data/table/table-data.slice.ts
@@ -10,11 +10,7 @@ import {
 } from '@reduxjs/toolkit'
 
 import TableDataServices from './table-data.services'
-import {
-  type TableData,
-  type TableDataOptions,
-  type TableInfo,
-} from './table-data.types'
+import { type TableDataOptions, type TableInfo } from './table-data.types'
 import { type Maybe } from '../../types'
 import { isEmpty } from '../../utils/helpers'
 
@@ -53,12 +49,13 @@ export const getTableData = createAsyncThunk(
     pageSize = 10000,
     deferred = false,
   }: TableDataOptions & { variables: string[] }) => {
-    return (await TableDataServices.getTableData(['run', ...variables], {
+    return await TableDataServices.getTableData({
       proposal,
+      variables: ['run', ...variables],
       page,
       pageSize,
       deferred,
-    })) as TableData
+    })
   }
 )
 

--- a/frontend/packages/ui/src/data/table/table-data.types.ts
+++ b/frontend/packages/ui/src/data/table/table-data.types.ts
@@ -26,6 +26,7 @@ export type TableDataOptions = {
   pageSize?: number
   lightweight?: boolean
   deferred?: boolean
+  variables?: string[]
 }
 
 export type TableMetadataOptions = {

--- a/frontend/packages/ui/src/graphql/apollo.ts
+++ b/frontend/packages/ui/src/graphql/apollo.ts
@@ -129,11 +129,7 @@ const splitLink = split(
   from([priorityLink, httpLink])
 )
 
-export const cache = new InMemoryCache({
-  possibleTypes: {
-    DamnitRun: ['p.*'],
-  },
-})
+export const cache = new InMemoryCache()
 
 export const client = new ApolloClient({
   cache,

--- a/frontend/packages/ui/src/hooks/use-proposal.ts
+++ b/frontend/packages/ui/src/hooks/use-proposal.ts
@@ -1,11 +1,11 @@
 import { useEffect } from 'react'
 
-import { useMutation, useSubscription } from '@apollo/client/react'
+import { useQuery, useSubscription } from '@apollo/client/react'
 
 import { updateTable } from '../data/table'
 import { setProposalNotFound, setProposalSuccess } from '../data/metadata'
 import {
-  REFRESH_MUTATION,
+  TABLE_METADATA_QUERY,
   LATEST_DATA_FIELD_NAME,
   LATEST_DATA_SUBSCRIPTION,
 } from '../data/table'
@@ -30,27 +30,33 @@ const useProposal = ({ subscribe = true }: UseProposalOptions) => {
     skip: !subscribe || proposal.loading || proposal.notFound,
   })
 
-  // Synchronize the server and the client table data
-  const [refresh, _] = useMutation(REFRESH_MUTATION)
+  // Synchronize the server and the client table metadata
+  const { data: metadataResult, error: metadataError } = useQuery(
+    TABLE_METADATA_QUERY,
+    {
+      variables: { proposal: proposal.value },
+      skip: !proposal.value,
+    }
+  )
+
   useEffect(() => {
-    if (!proposal.value) {
+    if (metadataError) {
+      dispatch(setProposalNotFound())
       return
     }
 
-    refresh({
-      variables: { proposal: proposal.value },
-      onCompleted: ({ refresh }) => {
-        dispatch(updateTable({ data: {}, metadata: refresh.metadata }))
+    const metadata = metadataResult?.metadata
+    if (metadata === undefined) {
+      return
+    }
 
-        // Finalize
-        dispatch(setProposalSuccess())
-      },
-      onError: (_) => {
-        // Finalize
-        dispatch(setProposalNotFound())
-      },
-    })
-  }, [proposal.value, refresh, dispatch])
+    const normalized = {
+      ...metadata,
+      runs: metadata.runs.map(String),
+    }
+    dispatch(updateTable({ data: {}, metadata: normalized }))
+    dispatch(setProposalSuccess())
+  }, [metadataResult, metadataError, dispatch])
 
   return proposal
 }

--- a/frontend/packages/ui/src/hooks/use-proposal.ts
+++ b/frontend/packages/ui/src/hooks/use-proposal.ts
@@ -36,6 +36,7 @@ const useProposal = ({ subscribe = true }: UseProposalOptions) => {
     {
       variables: { proposal: proposal.value },
       skip: !proposal.value,
+      fetchPolicy: 'cache-and-network',
     }
   )
 


### PR DESCRIPTION
This follows the GraphQL run query refactor on #193 that uses flat variables. We have now removed the `refresh` mutation and directly query the metadata via the `useQuery` hook.

Deployed it in the test environment, the table looks funky at the moment, but it works now.
(I'll take a look on the secondary headers and the bottom padding of the table)

https://damnit-test.xfel.eu/app/proposal/900485