### PR TITLE
feat(api): enable local development mode with --path flag

### DIFF
--- a/api/src/damnit_api/auth/__init__.py
+++ b/api/src/damnit_api/auth/__init__.py
@@ -3,7 +3,7 @@ from authlib.integrations.starlette_client import (  # type: ignore[import-untyp
 )
 
 from .bootstrap import bootstrap as bootstrap
-from .routers import router
+from .routers import noauth_router, router
 
 global __CLIENT
 
@@ -11,4 +11,4 @@ __CLIENT: StarletteOAuth2App = None  # type: ignore[assignment]
 """Global/singleton OAuth client instance."""
 
 
-__all__ = ["bootstrap", "router"]
+__all__ = ["bootstrap", "noauth_router", "router"]

--- a/api/src/damnit_api/auth/bootstrap.py
+++ b/api/src/damnit_api/auth/bootstrap.py
@@ -9,7 +9,7 @@ from .. import get_logger
 logger = get_logger()
 
 if TYPE_CHECKING:
-    from ..shared.settings import Settings
+    from ..shared.settings import AuthSettings, Settings
 
 
 global __OAUTH
@@ -20,6 +20,10 @@ __OAUTH: OAuth = None  # type: ignore[assignment]
 async def bootstrap(settings: "Settings"):
     """Bootstrap auth module - registers client defined in settings to [`.__OAUTH`] as
     `damnit_web` and sets [`damnit_api.auth.__CLIENT`] to [`.__OAUTH.damnit_web`]."""
+    if settings.auth is None:
+        await logger.awarning("Auth is disabled, skipping OAuth bootstrap")
+        return
+
     import damnit_api.auth
 
     global __OAUTH
@@ -27,21 +31,21 @@ async def bootstrap(settings: "Settings"):
 
     if damnit_api.auth.__CLIENT is None:
         await logger.ainfo("Configuring OAuth client")
-        _register(settings)
+        _register(settings.auth)
         damnit_api.auth.__CLIENT = __OAUTH.damnit_web  # type: ignore[assignment, no-redef]
         await damnit_api.auth.__CLIENT.load_server_metadata()  # pyright: ignore[reportOptionalMemberAccess]
     else:
         await logger.awarning("OAuth client already configured")
 
 
-def _register(settings: "Settings"):
+def _register(auth: "AuthSettings"):
     """Register the OAuth client defined in settings to [`.__OAUTH`] as `damnit_web`."""
     global __OAUTH
     __OAUTH.register(
         name="damnit_web",
-        client_id=settings.auth.client_id,
-        client_secret=settings.auth.client_secret.get_secret_value(),
-        server_metadata_url=str(settings.auth.server_metadata_url),
+        client_id=auth.client_id,
+        client_secret=auth.client_secret.get_secret_value(),
+        server_metadata_url=str(auth.server_metadata_url),
         client_kwargs={"scope": "openid email groups"},
     )
 

--- a/api/src/damnit_api/auth/gql.py
+++ b/api/src/damnit_api/auth/gql.py
@@ -29,6 +29,16 @@ class User:
         self, info: "strawberry.Info[Context]", start_after: datetime | None = None
     ) -> list[ProposalMeta]:
         """List of proposals for the user."""
+        from ..shared.settings import settings
+
+        if settings.is_local:
+            from ..metadata.services import _local_proposal_meta, _local_proposal_number
+
+            proposal_number = await _local_proposal_number()
+            if proposal_number is None:
+                return []
+            return [ProposalMeta.from_pydantic(_local_proposal_meta(proposal_number))]
+
         mymdc, session = info.context.mymdc, info.context.session
 
         proposals = await mymdc.get_user_proposals(self.preferred_username)

--- a/api/src/damnit_api/auth/models.py
+++ b/api/src/damnit_api/auth/models.py
@@ -41,10 +41,24 @@ class OAuthUserInfo(BaseUserInfo):
         """
         user_dict = connection.session.get("user")
         if user_dict is None:
+            from ..shared.settings import settings
+
+            if settings.is_local:
+                return DEV_USER  # type: ignore[return-value]
             msg = "No user info in session"
             raise ValueError(msg)
 
         return cls.model_validate(user_dict)
+
+
+DEV_USER = OAuthUserInfo(
+    email="dev@localhost",
+    family_name="Developer",
+    given_name="Local",
+    groups=[],
+    name="Local Developer",
+    preferred_username="dev",
+)
 
 
 class ProposalsByYearHalf(RootModel):
@@ -82,6 +96,16 @@ class User(BaseUserInfo):
     async def from_oauth_user(
         cls, mymdc: MyMdCClient, session: DBSession, oauth: OAuthUserInfo
     ) -> Self:
+        from ..shared.settings import settings
+
+        if settings.is_local:
+            res = cls.model_validate({
+                **oauth.model_dump(),
+                "proposals_by_year_half": {},
+            })
+            res._proposals = []
+            return res
+
         from ..metadata.services import _get_proposal_meta_many
 
         proposals = await mymdc.get_user_proposals(oauth.preferred_username)

--- a/api/src/damnit_api/auth/routers.py
+++ b/api/src/damnit_api/auth/routers.py
@@ -133,3 +133,29 @@ async def userinfo(
         user = models.OAuthUserInfo.from_connection(request)
 
     return user
+
+
+# -----------------------------------------------------------------------------
+# No-auth mode
+
+noauth_router = APIRouter(prefix="/oauth", tags=["auth"])
+
+
+@noauth_router.get("/userinfo")
+async def noauth_userinfo():
+    from ..metadata.services import LOCAL_CYCLE, _local_proposal_number
+
+    proposals = {}
+    proposal_number = await _local_proposal_number()
+    if proposal_number:
+        proposals = {LOCAL_CYCLE: [proposal_number]}
+
+    return {**models.DEV_USER.model_dump(), "proposals_by_year_half": proposals}
+
+
+@noauth_router.post("/logout")
+async def noauth_logout(request: Request):
+    request.session.pop("user", None)
+    response = JSONResponse(status_code=200, content={"logout_url": None})
+    response.delete_cookie("session", path="/")
+    return response

--- a/api/src/damnit_api/data.py
+++ b/api/src/damnit_api/data.py
@@ -5,6 +5,7 @@ import xarray as xr
 from damnit.api import Damnit, DataType
 from PIL import Image
 
+from .db import get_damnit_path
 from .shared.const import DamnitType
 from .utils import b64image
 
@@ -12,8 +13,9 @@ NOT_SUPPORTED_MESSAGE = "Not supported."
 
 
 def get_preview_data(proposal, run, variable):
+    path = get_damnit_path(str(proposal))
     try:
-        var_data = Damnit(proposal)[run, variable]
+        var_data = Damnit(path)[run, variable]
     except KeyError:
         return standardize(None, name=variable, dtype=DamnitType.NONE.value)
 

--- a/api/src/damnit_api/db.py
+++ b/api/src/damnit_api/db.py
@@ -205,6 +205,11 @@ async def async_variable_tags(proposal):
 
 def get_damnit_path(proposal_number: str = DEFAULT_PROPOSAL) -> str:
     """Returns the directory of the given proposal."""
+    from .shared.settings import settings
+
+    if settings.is_local:
+        return str(settings.damnit_path)
+
     path = find_proposal(proposal_number)
     if not path:
         msg = f"Proposal '{proposal_number}' is not found."

--- a/api/src/damnit_api/graphql/queries.py
+++ b/api/src/damnit_api/graphql/queries.py
@@ -24,6 +24,11 @@ async def _ensure_proposal_damnit_path(info: Info, proposal: str) -> None:
     """Resolve the user, check access, and ensure the proposal has a DAMNIT
     path. Refreshes from MyMdC if the cached metadata has no path.
     """
+    from ..shared.settings import settings
+
+    if settings.is_local:
+        return
+
     user = await User.from_oauth_user(
         info.context.mymdc, info.context.session, info.context.oauth_user
     )
@@ -227,10 +232,7 @@ class Query:
         # TODO: Convert to Strawberry type
         # and make it analogous to DamitVariable; e.g. `data`
         return get_preview_data(  # FIX: # pyright: ignore[reportReturnType]
-            proposal=int(
-                # FIXME: database.proposal is loosely typed
-                database.proposal  # pyright: ignore[reportArgumentType, reportReturnType]
-            ),
+            proposal=database.proposal,
             run=run,
             variable=variable,
         )

--- a/api/src/damnit_api/main.py
+++ b/api/src/damnit_api/main.py
@@ -34,25 +34,31 @@ def create_app():
             for bs in bootstraps:
                 tg.create_task(bs(settings))
 
-        app.router.include_router(auth.router)
+        if settings.is_local:
+            app.router.include_router(auth.noauth_router)
+        else:
+            app.router.include_router(auth.router)
         app.router.include_router(metadata.router)
         app.router.include_router(contextfile.router)
         app.router.include_router(gql.get_gql_app(), prefix="/graphql")
         yield
 
-    app = FastAPI(
-        lifespan=lifespan,
-        swagger_ui_init_oauth={
+    swagger_oauth = (
+        None
+        if settings.auth is None
+        else {
             "usePkceWithAuthorizationCodeGrant": True,
             "clientId": settings.auth.client_id,
-        },
+        }
     )
+    app = FastAPI(lifespan=lifespan, swagger_ui_init_oauth=swagger_oauth)
 
     @app.exception_handler(HTTPException)
     async def http_exception_handler(request: Request, exc: HTTPException):  # noqa: RUF029
         request_path = request.url.path
         if (
-            exc.status_code == status.HTTP_401_UNAUTHORIZED
+            not settings.is_local
+            and exc.status_code == status.HTTP_401_UNAUTHORIZED
             and request_path in KNOWN_PATHS
         ):
             return RedirectResponse(url=f"/oauth/login?redirect_uri={request_path}")
@@ -83,7 +89,7 @@ def create_app():
 
     app.add_middleware(
         SessionMiddleware,
-        secret_key=settings.session_secret.get_secret_value(),
+        secret_key=settings.session_secret.get_secret_value(),  # pyright: ignore[reportOptionalMemberAccess]
     )
 
     app.add_middleware(RequestLoggingMiddleware)
@@ -101,6 +107,33 @@ def create_app():
 
 
 if __name__ == "__main__":
+    import argparse
+    import os
+
+    parser = argparse.ArgumentParser(description="DAMNIT Web API Server")
+    parser.add_argument("--path", type=str, help="Path to amore/damnit directory")
+    args = parser.parse_args()
+
+    if args.path:
+        from pathlib import Path
+
+        path = Path(args.path)
+        if not path.is_dir():
+            parser.error(f"'{args.path}' does not exist or is not a directory")
+
+        missing = [
+            name
+            for name in ("runs.sqlite", "context.py", "extracted_data")
+            if not (path / name).exists()
+        ]
+        if missing:
+            parser.error(
+                f"'{args.path}' is not a valid DAMNIT directory"
+                f" (missing: {', '.join(missing)})"
+            )
+
+        os.environ["DW_API_DAMNIT_PATH"] = args.path
+
     import uvicorn
 
     from . import _logging, get_logger
@@ -113,9 +146,6 @@ if __name__ == "__main__":
     )
 
     logger = get_logger()
-
-    # TODO: warning/logging for address bind to localhost only which is aware
-    # of running in container/in front of reverse proxy?
 
     logger.debug("Settings", **settings.model_dump())
 

--- a/api/src/damnit_api/metadata/gql.py
+++ b/api/src/damnit_api/metadata/gql.py
@@ -36,8 +36,16 @@ class Query:
         proposal_numbers: list[int],
     ) -> list[ProposalMeta] | None:
         """Fetch metadata for the provided proposal number."""
+        from ..shared.settings import settings
+
         if info.context.request is None:
             return None
+
+        if settings.is_local:
+            return [
+                ProposalMeta.from_pydantic(services._local_proposal_meta(n))
+                for n in proposal_numbers
+            ]
 
         mymdc, session = info.context.mymdc, info.context.session
 

--- a/api/src/damnit_api/metadata/services.py
+++ b/api/src/damnit_api/metadata/services.py
@@ -21,6 +21,46 @@ if TYPE_CHECKING:
     from ..auth.dependencies import User
 
 
+LOCAL_CYCLE = "197001"
+
+
+def _local_proposal_meta(proposal_number: ProposalNumber) -> ProposalMeta:
+    """Synthetic metadata for local/dev mode."""
+    from ..shared.settings import settings
+
+    return ProposalMeta(
+        id=0,
+        number=proposal_number,
+        cycle=LOCAL_CYCLE,
+        instrument="LOC",
+        path=str(settings.damnit_path),
+        title=str(settings.damnit_path),
+        principal_investigator="Local Development",
+        start_date=datetime(1970, 1, 1, tzinfo=UTC),
+        end_date=None,
+        damnit_path=str(settings.damnit_path),
+    )
+
+
+async def _local_proposal_number() -> int | None:
+    from sqlalchemy import select
+
+    from ..db import async_table, get_session
+    from ..shared.const import DEFAULT_PROPOSAL
+
+    table = await async_table(DEFAULT_PROPOSAL, name="metameta")
+    if table is None:
+        return None
+
+    async with get_session(DEFAULT_PROPOSAL) as session:
+        result = await session.execute(
+            select(table.c.value).where(table.c.key == "proposal")
+        )
+        value = result.scalar()
+
+    return int(value) if value else None
+
+
 async def _fetch_proposal_meta(
     client: "MyMdCClient", proposal_number: ProposalNumber
 ) -> ProposalMetaBase:
@@ -122,6 +162,11 @@ async def _check_user_allowed(
 
     Raises `ForbiddenError` if not allowed.
     """
+    from ..shared.settings import settings
+
+    if settings.is_local:
+        return
+
     if proposal_number not in user._proposals:
         msg = (
             f"User not authorised for proposal {proposal_number}, or proposal does not "
@@ -218,6 +263,10 @@ async def get_proposal_meta(
 ) -> ProposalMeta:
     """Get proposal metadata by proposal number, using the repository and/or provided
     MyMdC Client."""
+    from ..shared.settings import settings
+
+    if settings.is_local:
+        return _local_proposal_meta(proposal_number)
 
     await _check_user_allowed(proposal_number, user)
 

--- a/api/src/damnit_api/shared/settings.py
+++ b/api/src/damnit_api/shared/settings.py
@@ -8,6 +8,7 @@ from pydantic import (
     SecretStr,
     UrlConstraints,
     field_validator,
+    model_validator,
 )
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -45,7 +46,9 @@ class UvicornSettings(BaseModel):
 
 
 class Settings(BaseSettings):
-    auth: AuthSettings
+    auth: AuthSettings | None = None
+
+    damnit_path: Path | None = None
 
     db_path: Path = Path(__file__).parents[3] / "dw_api.sqlite"
 
@@ -53,9 +56,33 @@ class Settings(BaseSettings):
 
     log_level: str = "DEBUG"
 
-    session_secret: SecretStr
+    session_secret: SecretStr | None = None
 
     uvicorn: UvicornSettings = UvicornSettings()
+
+    @property
+    def is_local(self) -> bool:
+        return self.damnit_path is not None
+
+    @model_validator(mode="after")
+    def _apply_local_mode(self):
+        if self.is_local:
+            self.auth = None
+            if self.session_secret is None:
+                self.session_secret = SecretStr("dev-secret")
+        elif self.auth is None:
+            msg = (
+                "auth settings are required when not in local mode"
+                " (set damnit_path for local development)"
+            )
+            raise ValueError(msg)
+        elif self.session_secret is None:
+            msg = (
+                "session_secret is required when not in local mode"
+                " (set damnit_path for local development)"
+            )
+            raise ValueError(msg)
+        return self
 
     mymdc: MyMdCClientSettings = MyMdCMockSettings(
         mock_responses_file=Path(__file__).parents[3] / "tests" / "mock" / "_mymdc.json"

--- a/api/tests/graphql/test_queries.py
+++ b/api/tests/graphql/test_queries.py
@@ -42,9 +42,9 @@ def mocked_fetch_info(mocker):
     )
 
 
-@pytest.fixture
-def mocked_metadata_auth(mocker):
-    """Bypass the auth + damnit_path check on the metadata query."""
+@pytest.fixture(autouse=True)
+def mocked_proposal_auth(mocker):
+    """Bypass the proposal check; tests run without a request context."""
     mocker.patch(
         "damnit_api.graphql.queries._ensure_proposal_damnit_path",
         return_value=None,
@@ -261,7 +261,7 @@ async def test_runs_query_fetches_run_info_when_metadata_requested(
 
 
 @pytest.mark.asyncio
-async def test_metadata_query(graphql_schema, mocked_metadata_auth):
+async def test_metadata_query(graphql_schema):
     query = """
         query TableMetadataQuery($proposal: String) {
           metadata(database: { proposal: $proposal })

--- a/api/tests/test_data.py
+++ b/api/tests/test_data.py
@@ -226,6 +226,7 @@ DAMNIT_CLASS_PATH = "damnit_api.data.Damnit"
 
 
 def mock_damnit_class(mocker, *, data, type_hint):
+    mocker.patch("damnit_api.data.get_damnit_path", return_value="/mock/path")
     mock_variable = mocker.Mock(
         preview_data=mocker.Mock(return_value=None),
         type_hint=mocker.Mock(return_value=type_hint),


### PR DESCRIPTION
This PR adds a local development mode that bypasses OAuth and MyMdC, letting the API serve a single DAMNIT directory from the local machine.

One can now run: `uv run -m damnit_api.main --path /path/to/damnit/dir` 🥳 

When --path is set, `auth` and `session_secret` become optional. A no-auth router replaces the OAuth router, and a synthetic local user is injected. Metadata queries return synthetic proposal metadata derived from the database's `metameta` table instead of calling MyMdC.