### PR TITLE
fix(api/db): minimize sqlite locking on network filesystems

### DIFF
--- a/api/scripts/reproduce-read-lock.py
+++ b/api/scripts/reproduce-read-lock.py
@@ -101,6 +101,7 @@ async def _single_reader(deadline):
     from damnit_api.db import (
         async_all_tags,
         async_latest_rows,
+        async_table,
         async_variable_tags,
         async_variables,
     )
@@ -112,9 +113,12 @@ async def _single_reader(deadline):
     while time.monotonic() < deadline:
         try:
             await async_variables(PROPOSAL_LABEL)
+            run_variables = await async_table(
+                PROPOSAL_LABEL, name="run_variables"
+            )
             await async_latest_rows(
                 PROPOSAL_LABEL,
-                table="run_variables",
+                table=run_variables,
                 by="timestamp",
                 start_at=0,
             )
@@ -156,7 +160,20 @@ def stage_copy(damnit_dir, scratch_dir):
     scratch_dir.mkdir(parents=True, exist_ok=True)
     staging = scratch_dir / f"repro-{uuid.uuid4().hex[:8]}"
     staging.mkdir()
-    shutil.copyfile(src, staging / "runs.sqlite")
+    dst = staging / "runs.sqlite"
+    shutil.copyfile(src, dst)
+
+    # Some older sqlites lack tags/variable_tags. Create empty placeholders
+    # so both branches exercise the same read path on this scratch copy.
+    import sqlite3
+    with sqlite3.connect(dst) as conn:
+        conn.executescript(
+            "CREATE TABLE IF NOT EXISTS tags ("
+            "id INTEGER PRIMARY KEY, name TEXT);"
+            "CREATE TABLE IF NOT EXISTS variable_tags ("
+            "variable_name TEXT, tag_id INTEGER);"
+        )
+
     return staging
 
 

--- a/api/scripts/reproduce-read-lock.py
+++ b/api/scripts/reproduce-read-lock.py
@@ -1,0 +1,326 @@
+"""Reproduce the writer-side `database is locked` error against the
+production read path in `damnit_api.db`.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+DEFAULT_DURATION = 30.0
+DEFAULT_WRITER_TIMEOUT = 0.0
+DEFAULT_READERS = 1
+PROPOSAL_LABEL = "__repro__"
+
+
+# ---------------------------------------------------------------------------
+# Writer subprocess
+#
+# Runs in a separate interpreter so its lock requests go through the kernel
+# and contend with the parent's read locks. `PRAGMA user_version` is a
+# schema-independent write that requires EXCLUSIVE.
+
+WRITER_SOURCE = r"""
+import json
+import signal
+import sqlite3
+import sys
+import time
+
+db_path = sys.argv[1]
+duration = float(sys.argv[2])
+writer_timeout = float(sys.argv[3])
+
+stop = False
+
+def _stop(*_):
+    global stop
+    stop = True
+
+signal.signal(signal.SIGTERM, _stop)
+signal.signal(signal.SIGINT, _stop)
+
+conn = sqlite3.connect(
+    db_path, timeout=writer_timeout, isolation_level=None,
+)
+
+attempts = 0
+successes = 0
+lock_errors = 0
+other_errors = 0
+counter = 0
+last_report = time.monotonic()
+deadline = time.monotonic() + duration
+
+while not stop and time.monotonic() < deadline:
+    attempts += 1
+    try:
+        conn.execute(f"PRAGMA user_version = {counter}")
+        successes += 1
+        counter += 1
+    except sqlite3.OperationalError as exc:
+        if "database is locked" in str(exc):
+            lock_errors += 1
+        else:
+            other_errors += 1
+    now = time.monotonic()
+    if now - last_report >= 1.0:
+        sys.stdout.write(json.dumps({
+            "kind": "tick",
+            "attempts": attempts,
+            "successes": successes,
+            "lock_errors": lock_errors,
+            "other_errors": other_errors,
+        }) + "\n")
+        sys.stdout.flush()
+        last_report = now
+    time.sleep(0.001)
+
+sys.stdout.write(json.dumps({
+    "kind": "final",
+    "attempts": attempts,
+    "successes": successes,
+    "lock_errors": lock_errors,
+    "other_errors": other_errors,
+}) + "\n")
+sys.stdout.flush()
+"""
+
+
+# ---------------------------------------------------------------------------
+# Reader
+
+async def _single_reader(deadline):
+    from damnit_api.db import (
+        async_all_tags,
+        async_latest_rows,
+        async_variable_tags,
+        async_variables,
+    )
+
+    ops = 0
+    lock_errors = 0
+    other_errors = 0
+
+    while time.monotonic() < deadline:
+        try:
+            await async_variables(PROPOSAL_LABEL)
+            await async_latest_rows(
+                PROPOSAL_LABEL,
+                table="run_variables",
+                by="timestamp",
+                start_at=0,
+            )
+            await async_all_tags(PROPOSAL_LABEL)
+            await async_variable_tags(PROPOSAL_LABEL)
+            ops += 4
+        except Exception as exc:  # noqa: BLE001
+            if "database is locked" in str(exc):
+                lock_errors += 1
+            else:
+                other_errors += 1
+
+    return ops, lock_errors, other_errors
+
+
+async def reader_loop(duration, readers):
+    deadline = time.monotonic() + duration
+    results = await asyncio.gather(
+        *[_single_reader(deadline) for _ in range(readers)]
+    )
+    total_ops = total_locks = total_others = 0
+    for ops, locks, others in results:
+        total_ops += ops
+        total_locks += locks
+        total_others += others
+    return total_ops, total_locks, total_others
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+
+def stage_copy(damnit_dir, scratch_dir):
+    src = damnit_dir / "runs.sqlite"
+    if not src.is_file():
+        raise SystemExit(
+            f"--damnit-dir does not contain runs.sqlite: {src}"
+        )
+
+    scratch_dir.mkdir(parents=True, exist_ok=True)
+    staging = scratch_dir / f"repro-{uuid.uuid4().hex[:8]}"
+    staging.mkdir()
+    shutil.copyfile(src, staging / "runs.sqlite")
+    return staging
+
+
+def patch_path(staging):
+    """Point damnit_api.db at the staged copy."""
+    import damnit_api.db as db_module
+    import damnit_api.utils as utils_module
+
+    staged_path = str(staging)
+    db_module.get_damnit_path = lambda *_a, **_kw: staged_path
+    db_module.find_proposal = lambda *_a, **_kw: staged_path
+    utils_module.find_proposal = lambda *_a, **_kw: staged_path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Reproduce writer-side SQLITE_BUSY against the API read path",
+    )
+    parser.add_argument(
+        "--damnit-dir",
+        type=Path,
+        required=True,
+        help="DAMNIT amore folder containing runs.sqlite",
+    )
+    parser.add_argument(
+        "--scratch-dir",
+        type=Path,
+        required=True,
+        help="Parent dir for the per-run staging copy",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=DEFAULT_DURATION,
+        help=f"Test duration in seconds (default {DEFAULT_DURATION:.0f})",
+    )
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="Keep the staging copy on exit instead of deleting it",
+    )
+    parser.add_argument(
+        "--no-writer",
+        action="store_true",
+        help="Skip the writer subprocess (sanity-check the reader)",
+    )
+    parser.add_argument(
+        "--writer-timeout",
+        type=float,
+        default=DEFAULT_WRITER_TIMEOUT,
+        help=(
+            "Writer's sqlite3 busy-retry budget in seconds (default 0)."
+            " The DAMNIT backend uses 30."
+        ),
+    )
+    parser.add_argument(
+        "--readers",
+        type=int,
+        default=DEFAULT_READERS,
+        help="Number of concurrent reader coroutines (default 1).",
+    )
+    return parser.parse_args()
+
+
+def empty_summary():
+    return {
+        "attempts": 0,
+        "successes": 0,
+        "lock_errors": 0,
+        "other_errors": 0,
+    }
+
+
+def collect_writer(writer):
+    summary = empty_summary()
+    try:
+        stdout, stderr = writer.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        writer.send_signal(signal.SIGTERM)
+        stdout, stderr = writer.communicate(timeout=5)
+
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("kind") == "final":
+            summary = event
+
+    if writer.returncode and stderr.strip():
+        sys.stderr.write("writer stderr:\n" + stderr)
+
+    return summary
+
+
+def main():
+    args = parse_args()
+
+    staging = stage_copy(args.damnit_dir, args.scratch_dir)
+    print(f"staged copy: {staging}")
+    patch_path(staging)
+
+    writer = None
+    writer_summary = empty_summary()
+    try:
+        if not args.no_writer:
+            writer = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    WRITER_SOURCE,
+                    str(staging / "runs.sqlite"),
+                    str(args.duration),
+                    str(args.writer_timeout),
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+
+        reader_ops, reader_locks, reader_others = asyncio.run(
+            reader_loop(args.duration, args.readers)
+        )
+
+        if writer is not None:
+            writer_summary = collect_writer(writer)
+            writer = None
+    finally:
+        if writer is not None and writer.poll() is None:
+            writer.send_signal(signal.SIGTERM)
+            writer.wait(timeout=5)
+        if not args.keep:
+            shutil.rmtree(staging, ignore_errors=True)
+
+    print()
+    print("--------- reproduction summary ---------"))
+    print(f"duration:        {args.duration:.1f} s")
+    print(
+        f"reader ops:      {reader_ops}"
+        f"  (lock errors: {reader_locks}, other errors: {reader_others})"
+    )
+    print(
+        f"writer attempts: {writer_summary['attempts']}"
+        f"  (lock errors: {writer_summary['lock_errors']},"
+        f" other errors: {writer_summary['other_errors']})"
+    )
+    print(f"writer success:  {writer_summary['successes']}")
+    print()
+
+    if args.no_writer:
+        print("(no writer; sanity check only)")
+        return 0
+    if writer_summary["lock_errors"] > 0:
+        print(
+            "REPRODUCED  the production read path on this branch causes"
+            " SQLITE_BUSY on the writer."
+        )
+        return 0
+    print(
+        "NOT REPRODUCED  raise --duration or check that the writer"
+        " subprocess actually ran."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/api/scripts/reproduce-read-lock.py
+++ b/api/scripts/reproduce-read-lock.py
@@ -292,7 +292,7 @@ def main():
             shutil.rmtree(staging, ignore_errors=True)
 
     print()
-    print("--------- reproduction summary ---------"))
+    print("--------- reproduction summary ---------")
     print(f"duration:        {args.duration:.1f} s")
     print(
         f"reader ops:      {reader_ops}"

--- a/api/src/damnit_api/db.py
+++ b/api/src/damnit_api/db.py
@@ -4,10 +4,12 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
 
+from async_lru import alru_cache
 from sqlalchemy import (
     MetaData,
     Table,
     desc,
+    func,
     select,
 )
 from sqlalchemy.exc import NoSuchTableError
@@ -94,15 +96,23 @@ def get_connection(proposal) -> AsyncConnection:
     ).connect()  # FIX: # pyright: ignore[reportReturnType]
 
 
-async def async_table(proposal, name: str = "runs") -> Table:
+@alru_cache(ttl=300)
+async def async_table(proposal, name: str = "runs") -> Table | None:
     async with get_connection(proposal) as conn:
-        return await conn.run_sync(
-            lambda conn: Table(name, MetaData(), autoload_with=conn)
-        )
+        try:
+            return await conn.run_sync(
+                lambda conn: Table(name, MetaData(), autoload_with=conn)
+            )
+        except NoSuchTableError:
+            # Don't cache misses; the table may appear shortly.
+            async_table.cache_invalidate(proposal, name)
+            return None
 
 
 async def async_variables(proposal):
     variables = await async_table(proposal, name="variables")
+    if variables is None:
+        return {}
     selection_variables = select(variables.c.name, variables.c.title)
     async with get_session(proposal) as session:
         result = await session.execute(selection_variables)
@@ -115,7 +125,7 @@ async def async_variables(proposal):
 async def async_latest_rows(
     proposal,
     *,
-    table: str | Table,
+    table: Table,
     by: str,
     start_at=None,
     descending=True,
@@ -124,14 +134,9 @@ async def async_latest_rows(
         start_at = datetime.now().astimezone().timestamp()
     order_by = desc(by) if descending else by
 
-    if isinstance(table, str):
-        table = await async_table(proposal, name=table)
-
     selection = (
         select(table)
-        .where(
-            table.c.get(by) > start_at  # FIX: # pyright: ignore[reportOptionalOperand]
-        )
+        .where(table.c.get(by) > start_at)
         .order_by(order_by)
     )
 
@@ -140,13 +145,21 @@ async def async_latest_rows(
     return result.mappings().all()  # FIX: # pyright: ignore[reportReturnType]
 
 
+async def async_max(proposal, *, table: str, column: str):
+    table = await async_table(proposal, name=table)
+    if table is None:
+        return None
+    selection = select(func.max(table.c.get(column)))
+    async with get_session(proposal) as session:
+        result = await session.execute(selection)
+    return result.scalar()
+
+
 async def async_column(proposal, *, table: str, name: str):
-    table = await async_table(
-        proposal, name=table
-    )  # FIX:  # pyright: ignore[reportAssignmentType]
-    selection = select(
-        table.c.get(name)  # FIX:  # pyright: ignore[reportAttributeAccessIssue]
-    )
+    table = await async_table(proposal, name=table)
+    if table is None:
+        return []
+    selection = select(table.c.get(name))
 
     async with get_session(proposal) as session:
         result = await session.execute(selection)
@@ -156,6 +169,8 @@ async def async_column(proposal, *, table: str, name: str):
 
 async def async_all_tags(proposal):
     tags_table = await async_table(proposal, name="tags")
+    if tags_table is None:
+        return {}
     selection = select(
         tags_table.c.id,
         tags_table.c.name,
@@ -167,21 +182,21 @@ async def async_all_tags(proposal):
 
 
 async def async_variable_tags(proposal):
-    try:
-        variable_tags_table = await async_table(proposal, name="variable_tags")
-        selection = select(
-            variable_tags_table.c.variable_name, variable_tags_table.c.tag_id
-        )
-        async with get_session(proposal) as session:
-            result = await session.execute(selection)
+    variable_tags_table = await async_table(proposal, name="variable_tags")
+    if variable_tags_table is None:
+        return {}
 
-        variable_tags: dict[str, list[int]] = defaultdict(list)
-        for row in result.mappings().all():
-            variable_tags[row["variable_name"]].append(row["tag_id"])
+    selection = select(
+        variable_tags_table.c.variable_name, variable_tags_table.c.tag_id
+    )
+    async with get_session(proposal) as session:
+        result = await session.execute(selection)
 
-        return variable_tags
-    except NoSuchTableError:
-        return []
+    variable_tags: dict[str, list[int]] = defaultdict(list)
+    for row in result.mappings().all():
+        variable_tags[row["variable_name"]].append(row["tag_id"])
+
+    return variable_tags
 
 
 # -----------------------------------------------------------------------------

--- a/api/src/damnit_api/db.py
+++ b/api/src/damnit_api/db.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
 )
+from sqlalchemy.pool import NullPool
 
 from .shared.const import DEFAULT_PROPOSAL
 from .utils import Registry, create_map, find_proposal
@@ -32,7 +33,11 @@ class DatabaseSessionManager(metaclass=Registry):
     def __init__(self, proposal: str = DEFAULT_PROPOSAL):
         self.proposal = proposal
         self.root_path = get_damnit_path(proposal)
-        self._engine = create_async_engine(self.db_path)
+        self._engine = create_async_engine(
+            self.db_path,
+            isolation_level="AUTOCOMMIT",
+            poolclass=NullPool,
+        )
         self._sessionmaker = async_sessionmaker(autocommit=False, bind=self._engine)
 
     @property

--- a/api/src/damnit_api/graphql/bootstrap.py
+++ b/api/src/damnit_api/graphql/bootstrap.py
@@ -24,7 +24,10 @@ async def bootstrap(proposal=db.DEFAULT_PROPOSAL):
     for name, var in variables.items():
         var["tags"] = [tags[tag]["name"] for tag in variable_tags.get(name, [])]
 
-    model.update(variables)
+    latest_timestamp = await db.async_max(
+        proposal, table="run_variables", column="timestamp"
+    )
+    model.update(variables, timestamp=latest_timestamp)
 
     # Popoulate tag model with variables
     for name, var_tags in variable_tags.items():

--- a/api/src/damnit_api/graphql/queries.py
+++ b/api/src/damnit_api/graphql/queries.py
@@ -29,6 +29,8 @@ def group_by_run(record):
 
 async def fetch_variables(proposal, *, limit, offset):
     table = await async_table(proposal, name="run_variables")
+    if table is None:
+        return []
 
     runs_subquery = (
         select(table.c.run)

--- a/api/src/damnit_api/graphql/subscriptions.py
+++ b/api/src/damnit_api/graphql/subscriptions.py
@@ -6,45 +6,43 @@ from async_lru import alru_cache
 from strawberry.scalars import JSON
 from strawberry.types import Info
 
-from ..db import async_latest_rows, async_variables
+from ..db import async_latest_rows, async_table, async_variables
 from ..utils import create_map, wrap_values
 from .models import Timestamp, get_model
 from .utils import DatabaseInput, LatestData, fetch_info
 
-POLLING_INTERVAL = 5  # seconds
+POLLING_INTERVAL = 1  # seconds
 
 
-@alru_cache(ttl=POLLING_INTERVAL)
-async def get_latest_data(proposal, timestamp, schema):
-    # Get latest data
-    latest_data = await async_latest_rows(
+# Per-client cursor is deliberately omitted from the cache key so that
+# concurrent subscribers coalesce into a single DB read per tick.
+@alru_cache(maxsize=32, ttl=POLLING_INTERVAL)
+async def poll_proposal(proposal, schema):
+    model = get_model(proposal)
+    table = await async_table(proposal, name="run_variables")
+    if table is None:
+        return None
+    rows = await async_latest_rows(
         proposal,
-        table="run_variables",
+        table=table,
         by="timestamp",
-        start_at=timestamp,
+        start_at=model.timestamp,
     )
-    if not len(latest_data):
+    if not rows:
         return None
 
-    latest_data = LatestData.from_list(latest_data)
-
-    # Get latest runs
-    latest_runs = await fetch_info(proposal, runs=list(latest_data.runs.keys()))
-    latest_runs = create_map(latest_runs, key="run")
-
-    # Update model
-    model = get_model(proposal)
-    latest_variables = await async_variables(proposal)
-    model_changed = model.update(
-        latest_variables,
-        timestamp=latest_data.timestamp,
+    latest_data = LatestData.from_list(rows)
+    latest_runs = create_map(
+        await fetch_info(proposal, runs=list(latest_data.runs.keys())),
+        key="run",
     )
-    if model_changed:
-        # Update GraphQL schema
+
+    latest_variables = await async_variables(proposal)
+    if model.update(latest_variables, timestamp=latest_data.timestamp):
         schema.update(model.stype)
 
-    # Aggregate run values from latest data and runs
     runs = {}
+    run_timestamps = {}
     for run, variables in latest_data.runs.items():
         run_values = {
             name: {"value": data.value, "summary_type": data.summary_type}
@@ -56,21 +54,40 @@ async def get_latest_data(proposal, timestamp, schema):
             run_values.update(wrap_values(run_info))
 
         runs[run] = model.resolve(**run_values)
+        run_timestamps[run] = max(
+            data.timestamp for data in variables.values()
+        )
 
-    # Return the latest values if any
-    if len(runs):
-        # Update the model with new runs
-        model.runs = sorted(set(model.runs + list(runs.keys())))
+    if not runs:
+        return None
 
-        metadata = {
-            "runs": model.runs,
-            "variables": model.variables,
-            "timestamp": model.timestamp * 1000,  # deserialize to JS
-        }
+    model.runs = sorted(set(model.runs + list(runs.keys())))
+    metadata = {
+        "runs": model.runs,
+        "variables": model.variables,
+        "timestamp": model.timestamp * 1000,  # deserialize to JS
+    }
+    return {
+        "runs": runs,
+        "run_timestamps": run_timestamps,
+        "max_timestamp": max(run_timestamps.values()),
+        "metadata": metadata,
+    }
 
-        return {"runs": runs, "metadata": metadata}
 
-    return None
+def filter_for_client(snapshot, since):
+    # A zero cursor means the client never completed REFRESH; skip the tick
+    # rather than flooding it with every row newer than epoch.
+    if snapshot is None or not since or snapshot["max_timestamp"] <= since:
+        return None
+    runs = {
+        run: value
+        for run, value in snapshot["runs"].items()
+        if snapshot["run_timestamps"][run] > since
+    }
+    if not runs:
+        return None
+    return {"runs": runs, "metadata": snapshot["metadata"]}
 
 
 @strawberry.type
@@ -83,13 +100,12 @@ class Subscription:
         timestamp: Timestamp,  # FIX: # pyright: ignore[reportInvalidTypeForm]
     ) -> AsyncGenerator[JSON]:  # FIX: # pyright: ignore[reportInvalidTypeForm]
         while True:
-            # Sleep first :)
             await asyncio.sleep(POLLING_INTERVAL)
 
-            result = await get_latest_data(
+            snapshot = await poll_proposal(
                 proposal=database.proposal,
-                timestamp=timestamp,
                 schema=info.schema,
             )
+            result = filter_for_client(snapshot, timestamp)
             if result is not None:
                 yield result  # FIX: # pyright: ignore[reportReturnType]

--- a/api/src/damnit_api/graphql/subscriptions.py
+++ b/api/src/damnit_api/graphql/subscriptions.py
@@ -11,7 +11,7 @@ from ..utils import create_map, wrap_values
 from .models import Timestamp, get_model
 from .utils import DatabaseInput, LatestData, fetch_info
 
-POLLING_INTERVAL = 1  # seconds
+POLLING_INTERVAL = 5  # seconds
 
 
 @alru_cache(ttl=POLLING_INTERVAL)

--- a/api/src/damnit_api/graphql/utils.py
+++ b/api/src/damnit_api/graphql/utils.py
@@ -64,6 +64,8 @@ class LatestData:
 
 async def fetch_info(proposal, *, runs):
     table = await async_table(proposal, name="run_info")
+    if table is None:
+        return []
     conditions = [table.c.run == run for run in runs]
     query = select(table).where(or_(*conditions)).order_by(table.c.run)
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+from damnit_api.db import DatabaseSessionManager
+
+
+@pytest.fixture(autouse=True)
+def _clear_db_session_manager_registry():
+    DatabaseSessionManager.registry.clear()
+    yield
+    DatabaseSessionManager.registry.clear()

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,10 +1,12 @@
 import pytest
 
-from damnit_api.db import DatabaseSessionManager
+from damnit_api.db import DatabaseSessionManager, async_table
 
 
 @pytest.fixture(autouse=True)
 def _clear_db_session_manager_registry():
     DatabaseSessionManager.registry.clear()
+    async_table.cache_clear()
     yield
     DatabaseSessionManager.registry.clear()
+    async_table.cache_clear()

--- a/api/tests/graphql/conftest.py
+++ b/api/tests/graphql/conftest.py
@@ -1,9 +1,12 @@
 import pytest
 import pytest_asyncio
+from strawberry.schema.config import StrawberryConfig
 
 from damnit_api.graphql.bootstrap import bootstrap
 from damnit_api.graphql.models import DamnitTable, get_stype
+from damnit_api.graphql.queries import Query
 from damnit_api.graphql.schema import Schema
+from damnit_api.graphql.subscriptions import Subscription, poll_proposal
 
 from .const import EXAMPLE_TAGS, EXAMPLE_VARIABLE_TAGS, EXAMPLE_VARIABLES, RUNS
 
@@ -12,6 +15,7 @@ from .const import EXAMPLE_TAGS, EXAMPLE_VARIABLE_TAGS, EXAMPLE_VARIABLES, RUNS
 def lifespan():
     DamnitTable.registry.clear()  # FIX: # pyright: ignore[reportAttributeAccessIssue]
     bootstrap.cache_clear()
+    poll_proposal.cache_clear()
     return
 
 
@@ -47,14 +51,27 @@ def mocked_bootstrap_column(mocker):
     )
 
 
+@pytest.fixture
+def mocked_bootstrap_max(mocker):
+    mocker.patch(
+        "damnit_api.graphql.bootstrap.db.async_max",
+        return_value=None,
+    )
+
+
 @pytest_asyncio.fixture
 async def graphql_schema(
     mocked_bootstrap_variables,
     mocked_bootstrap_column,
     mocked_bootstrap_all_tags,
     mock_bootstrap_variable_tags,
+    mocked_bootstrap_max,
 ):
-    schema = Schema()
+    schema = Schema(
+        query=Query,
+        subscription=Subscription,
+        config=StrawberryConfig(auto_camel_case=False),
+    )
 
     # Initialize
     await bootstrap(proposal="1234")

--- a/api/tests/graphql/const.py
+++ b/api/tests/graphql/const.py
@@ -78,14 +78,13 @@ NEW_DTYPES = {
 }
 
 EXAMPLE_TAGS = {
-    "1": {"id": 1, "name": "tag1"},
-    "2": {"id": 2, "name": "tag2"},
-    "3": {"id": 3, "name": "tag3"},
+    1: {"id": 1, "name": "tag1"},
+    2: {"id": 2, "name": "tag2"},
+    3: {"id": 3, "name": "tag3"},
 }
 
-EXAMPLE_VARIABLE_TAGS = [
-    {"variable_name": "integer", "tag_id": 1},
-    {"variable_name": "integer", "tag_id": 2},
-    {"variable_name": "float", "tag_id": 2},
-    {"variable_name": "string", "tag_id": 3},
-]
+EXAMPLE_VARIABLE_TAGS = {
+    "integer": [1, 2],
+    "float": [2],
+    "string": [3],
+}

--- a/api/tests/graphql/test_subscriptions.py
+++ b/api/tests/graphql/test_subscriptions.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from damnit_api.graphql.models import DamnitRun, serialize
-from damnit_api.graphql.subscriptions import POLLING_INTERVAL
+from damnit_api.graphql.subscriptions import POLLING_INTERVAL, filter_for_client
 
 from .const import (
     EXAMPLE_VARIABLES,
@@ -30,8 +30,14 @@ def current_timestamp():
 
 @pytest.fixture
 def mocked_latest_rows(mocker, current_timestamp):
+    table_sentinel = mocker.sentinel.run_variables_table
+    mocker.patch(
+        "damnit_api.graphql.subscriptions.async_table",
+        return_value=table_sentinel,
+    )
+
     def mocked_returns(*args, table, **kwargs):
-        if table == "run_variables":
+        if table is table_sentinel:
             return create_run_variables(
                 NEW_VALUES,
                 proposal=KNOWN_VALUES["proposal"],
@@ -80,43 +86,39 @@ async def test_latest_data(
         """,
         variable_values={
             "proposal": "1234",
-            "timestamp": current_timestamp * 1000,  # some arbitrary timestamp
+            "timestamp": (current_timestamp - 1) * 1000,  # before the new row
         },
         context_value={
             "schema": graphql_schema,
         },
     )
 
-    # Only test the first update
-    async for result in subscription:
-        assert not result.errors
+    result = await asyncio.wait_for(anext(subscription), timeout=2)
+    assert not result.errors
 
-        data = {**KNOWN_VALUES, **NEW_VALUES, "run": NEW_RUN}
-        dtypes = {**KNOWN_DTYPES, **NEW_DTYPES}
+    data = {**KNOWN_VALUES, **NEW_VALUES, "run": NEW_RUN}
+    dtypes = {**KNOWN_DTYPES, **NEW_DTYPES}
 
-        latest_data = result.data["latest_data"]
-        assert set(latest_data.keys()) == {"runs", "metadata"}
-        assert latest_data["runs"] == {
-            NEW_RUN: {
-                name: {
-                    "value": serialize(value, dtype=dtypes[name]),
-                    "dtype": dtypes[name].value,
-                }
-                for name, value in data.items()
+    latest_data = result.data["latest_data"]
+    assert set(latest_data.keys()) == {"runs", "metadata"}
+    assert latest_data["runs"] == {
+        NEW_RUN: {
+            name: {
+                "value": serialize(value, dtype=dtypes[name])[0],
+                "dtype": dtypes[name].value,
             }
+            for name, value in data.items()
         }
+    }
 
-        metadata = latest_data["metadata"]
-        assert set(metadata.keys()) == {"runs", "timestamp", "variables"}
-        assert metadata["runs"] == [*RUNS, NEW_RUN]
-        assert metadata["timestamp"] == current_timestamp * 1000
-        assert metadata["variables"] == {
-            **DamnitRun.known_variables(),
-            **EXAMPLE_VARIABLES,
-        }
-
-        # Don't forget to break!
-        break
+    metadata = latest_data["metadata"]
+    assert set(metadata.keys()) == {"runs", "timestamp", "variables"}
+    assert metadata["runs"] == [*RUNS, NEW_RUN]
+    assert metadata["timestamp"] == current_timestamp * 1000
+    assert metadata["variables"] == {
+        **DamnitRun.known_variables(),
+        **EXAMPLE_VARIABLES,
+    }
 
 
 @pytest.mark.asyncio
@@ -136,7 +138,7 @@ async def test_latest_data_with_concurrent_subscriptions(
         """
     variables = {
         "proposal": "1234",
-        "timestamp": current_timestamp * 1000,  # some arbitrary timestamp
+        "timestamp": (current_timestamp - 1) * 1000,  # before the new row
     }
     context = {
         "schema": graphql_schema,
@@ -154,20 +156,16 @@ async def test_latest_data_with_concurrent_subscriptions(
     )
 
     with patched_sleep:
-        async for result in first_sub:
-            # Only test the first update
-            assert not result.errors
-            mocked_latest_rows.assert_called()
-            break
+        result = await asyncio.wait_for(anext(first_sub), timeout=2)
+        assert not result.errors
+        mocked_latest_rows.assert_called()
 
     mocked_latest_rows.reset_mock()
 
     with patched_sleep:
-        async for result in second_sub:
-            # Only test the first update
-            assert not result.errors
-            mocked_latest_rows.assert_not_called()
-            break
+        result = await asyncio.wait_for(anext(second_sub), timeout=2)
+        assert not result.errors
+        mocked_latest_rows.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -187,7 +185,7 @@ async def test_latest_data_with_nonconcurrent_subscriptions(
         """
     variables = {
         "proposal": "1234",
-        "timestamp": current_timestamp * 1000,  # some arbitrary timestamp
+        "timestamp": (current_timestamp - 1) * 1000,  # before the new row
     }
     context = {
         "schema": graphql_schema,
@@ -205,18 +203,48 @@ async def test_latest_data_with_nonconcurrent_subscriptions(
     )
 
     with patched_sleep:
-        async for result in first_sub:
-            # Only test the first update
-            assert not result.errors
-            mocked_latest_rows.assert_called()
-            break
+        result = await asyncio.wait_for(anext(first_sub), timeout=2)
+        assert not result.errors
+        mocked_latest_rows.assert_called()
 
     await asyncio.sleep(POLLING_INTERVAL * 3)  # give enough time to clear the cache
     mocked_latest_rows.reset_mock()
 
     with patched_sleep:
-        async for result in second_sub:
-            # Only test the first update
-            assert not result.errors
-            mocked_latest_rows.assert_called()
-            break
+        result = await asyncio.wait_for(anext(second_sub), timeout=2)
+        assert not result.errors
+        mocked_latest_rows.assert_called()
+
+
+# -----------------------------------------------------------------------------
+# filter_for_client
+
+
+def _snapshot(run_timestamps):
+    runs = {run: {"value": run} for run in run_timestamps}
+    return {
+        "runs": runs,
+        "run_timestamps": run_timestamps,
+        "max_timestamp": max(run_timestamps.values()),
+        "metadata": {"runs": list(runs), "variables": {}, "timestamp": 0},
+    }
+
+
+def test_filter_for_client_none_snapshot():
+    assert filter_for_client(None, since=0) is None
+
+
+def test_filter_for_client_since_zero_returns_none():
+    snapshot = _snapshot({1: 100.0, 2: 200.0})
+    assert filter_for_client(snapshot, since=0) is None
+
+
+def test_filter_for_client_excludes_equal_timestamp():
+    snapshot = _snapshot({1: 100.0, 2: 200.0})
+    result = filter_for_client(snapshot, since=100.0)
+    assert set(result["runs"].keys()) == {2}
+
+
+def test_filter_for_client_since_above_all_returns_none():
+    snapshot = _snapshot({1: 100.0, 2: 200.0})
+    assert filter_for_client(snapshot, since=300.0) is None

--- a/api/tests/test_db.py
+++ b/api/tests/test_db.py
@@ -1,0 +1,89 @@
+"""Tests for the NullPool/AUTOCOMMIT engine configuration.
+
+The default pool keeps aiosqlite connections (and their underlying
+file descriptors to runs.sqlite) alive between operations. NullPool
+disposes the connection per checkout so no descriptor lingers when
+the engine is idle; AUTOCOMMIT keeps statements out of session-level
+transactions.
+"""
+
+import asyncio
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+from sqlalchemy.pool import NullPool
+
+from damnit_api.db import (
+    DAMNIT_PATH,
+    DatabaseSessionManager,
+    async_table,
+    get_session,
+)
+
+
+# -----------------------------------------------------------------------------
+# Fixtures
+
+RUNS_SCHEMA = """
+CREATE TABLE runs (
+    proposal INTEGER,
+    runnr INTEGER,
+    start_time REAL
+)
+"""
+
+
+@pytest.fixture
+def damnit_db(tmp_path):
+    root = tmp_path / DAMNIT_PATH
+    root.mkdir(parents=True)
+    db_file = root / "runs.sqlite"
+    conn = sqlite3.connect(str(db_file))
+    try:
+        conn.executescript(RUNS_SCHEMA)
+        conn.commit()
+    finally:
+        conn.close()
+    return str(tmp_path)
+
+
+def _open_file_descriptors_to(db_file: Path):
+    fd_dir = Path(f"/proc/{os.getpid()}/fd")
+    hits = []
+    for link in fd_dir.iterdir():
+        try:
+            target = os.readlink(link)
+        except OSError:
+            continue
+        if target == str(db_file):
+            hits.append(target)
+    return hits
+
+
+# -----------------------------------------------------------------------------
+# Engine configuration
+
+def test_engine_uses_nullpool_and_autocommit(damnit_db):
+    mgr = DatabaseSessionManager(damnit_db)
+    assert isinstance(mgr._engine.pool, NullPool)
+    # Private attribute: the public get_execution_options() does not
+    # surface the engine-level isolation_level for async engines.
+    assert mgr._engine.dialect._on_connect_isolation_level == "AUTOCOMMIT"
+
+
+# -----------------------------------------------------------------------------
+# File descriptor lifetime
+
+def test_no_lingering_file_descriptor_after_read(damnit_db):
+    db_file = Path(damnit_db) / DAMNIT_PATH / "runs.sqlite"
+
+    async def do_read():
+        table = await async_table(damnit_db, name="runs")
+        async with get_session(damnit_db) as session:
+            await session.execute(table.select())
+
+    assert _open_file_descriptors_to(db_file) == []
+    asyncio.run(do_read())
+    assert _open_file_descriptors_to(db_file) == []


### PR DESCRIPTION
This PR aims to mitigate the `"database is locked"` error that the DAMNIT listener reports when writing to the per-proposal database. A proper fix is still to be done; for now, we try to minimize the problem.

When using network file systems like GPFS, open file handles from pooled connections can sometimes interfere with `fcntl()` lock acquisition, even when no active transactions are happening. SQLAlchemy’s `AsyncAdaptedQueuePool` keeps connections active across requests by default, which increases the time window for competing locks to occur.

We now change how the `DatabaseSessionManager` engine is created:

- `NullPool`: connections are created and destroyed for each operation. This means file handles are released immediately. This is the main solution for the network file system issue.
- `AUTOCOMMIT` isolation mode: prevents implicit `BEGIN` statements for reads. The API server never writes to the `runs.sqlite` file, so this makes it clear that the file is read-only. It also prevents holding unnecessary transaction state.

We also reduce how often the read lock is held:

- Cache table lookups for 5 minutes instead of re-reading the table shape on every query. The schema lookup runs extra `PRAGMA` queries that kept the read lock open longer than the actual `SELECT`.
- Share one subscription poll across all clients on the same proposal, instead of each client triggering its own query. Per-client filtering happens in memory afterwards.

Still to do: find a way for bulk read queries not to interfere with writes to `runs.sqlite`.