### PR TITLE
feat(api/auth): use strawberry/gql permission classes

### DIFF
--- a/api/src/damnit_api/auth/permissions.py
+++ b/api/src/damnit_api/auth/permissions.py
@@ -1,0 +1,50 @@
+"""Strawberry permissions for GraphQL authorization."""
+
+from typing import TYPE_CHECKING, cast
+
+from strawberry.permission import BasePermission
+from strawberry.types import Info
+
+from ..metadata.services import _check_user_allowed
+from ..shared.errors import ForbiddenError
+from .models import User
+
+if TYPE_CHECKING:
+    from ..graphql.utils import DatabaseInput
+
+
+class IsAuthenticated(BasePermission):
+    message = "Authentication required."
+
+    async def has_permission(self, source, info: Info, **kwargs) -> bool:
+        return info.context is not None and info.context.oauth_user is not None
+
+
+class IsProposalMember(BasePermission):
+    message = "Access to this proposal is forbidden."
+
+    async def has_permission(self, source, info: Info, **kwargs) -> bool:
+        database = kwargs.get("database")
+        database = cast("DatabaseInput", database)
+        if database is None:
+            return False
+
+        try:
+            proposal = int(database.proposal.strip("p"))
+        except (ValueError, TypeError):
+            return False
+
+        if not hasattr(info.context, "user"):
+            info.context.user = await User.from_oauth_user(
+                info.context.mymdc, info.context.session, info.context.oauth_user
+            )
+        user = info.context.user
+
+        try:
+            await _check_user_allowed(proposal, user)
+            return True
+        except ForbiddenError:
+            return False
+
+
+PROPOSAL_PERMISSIONS = [IsAuthenticated, IsProposalMember]

--- a/api/src/damnit_api/graphql/queries.py
+++ b/api/src/damnit_api/graphql/queries.py
@@ -5,7 +5,7 @@ from strawberry.types import Info
 from strawberry.types.nodes import SelectedField
 
 from .. import get_logger
-from ..auth.models import User
+from ..auth.permissions import PROPOSAL_PERMISSIONS
 from ..data import get_preview_data
 from ..db import async_table, get_session
 from ..metadata.services import get_proposal_meta, update_proposal_meta
@@ -160,7 +160,7 @@ class Query:
     Defines the GraphQL queries for the Damnit API.
     """
 
-    @strawberry.field
+    @strawberry.field(permission_classes=PROPOSAL_PERMISSIONS)
     async def runs(
         self,
         info: Info,
@@ -200,7 +200,7 @@ class Query:
             for v, i in zip(variables, info_rows, strict=True)
         ]
 
-    @strawberry.field
+    @strawberry.field(permission_classes=PROPOSAL_PERMISSIONS)
     async def metadata(
         self,
         info: Info,
@@ -220,7 +220,7 @@ class Query:
             "timestamp": snapshot["timestamp"] * 1000,  # ms for JS
         }  # pyright: ignore[reportReturnType]
 
-    @strawberry.field
+    @strawberry.field(permission_classes=PROPOSAL_PERMISSIONS)
     async def extracted_data(
         self,
         info: Info,

--- a/api/src/damnit_api/graphql/queries.py
+++ b/api/src/damnit_api/graphql/queries.py
@@ -8,7 +8,8 @@ from .. import get_logger
 from ..auth.permissions import PROPOSAL_PERMISSIONS
 from ..data import get_preview_data
 from ..db import async_table, get_session
-from ..metadata.services import get_proposal_meta, update_proposal_meta
+from ..metadata.services import _get_proposal_meta, _update_proposal_meta
+from ..utils import wrap_values
 from .metadata import fetch_metadata
 from .models import KNOWN_DTYPES, DamnitRun
 from .utils import DatabaseInput, fetch_info
@@ -20,25 +21,18 @@ logger = get_logger()
 RUN_INFO_NAMES = frozenset(KNOWN_DTYPES) - {"proposal", "run"}
 
 
-async def _ensure_proposal_damnit_path(info: Info, proposal: str) -> None:
-    """Resolve the user, check access, and ensure the proposal has a DAMNIT
-    path. Refreshes from MyMdC if the cached metadata has no path.
+async def _ensure_damnit_path(info: Info, proposal: str) -> None:
+    """Ensure the proposal has a DAMNIT path, refreshing from MyMdC if needed.
+
+    Authorization is handled separately by IsProposalMember before this runs.
     """
-    from ..shared.settings import settings
-
-    if settings.is_local:
-        return
-
-    user = await User.from_oauth_user(
-        info.context.mymdc, info.context.session, info.context.oauth_user
-    )
-    meta = await get_proposal_meta(
-        info.context.mymdc, int(proposal), user, info.context.session
+    meta = await _get_proposal_meta(
+        info.context.mymdc, int(proposal), info.context.session
     )
     if not meta.damnit_path:
         logger.info("No damnit path found, updating proposal metadata")
-        meta = await update_proposal_meta(
-            info.context.mymdc, int(proposal), user, info.context.session
+        meta = await _update_proposal_meta(
+            info.context.mymdc, int(proposal), info.context.session
         )
         if not meta.damnit_path:
             msg = "No damnit path found after updating proposal metadata."
@@ -175,7 +169,7 @@ class Query:
         argument returns every variable for each run.
         """
         proposal = database.proposal
-        await _ensure_proposal_damnit_path(info, proposal)
+        await _ensure_damnit_path(info, proposal)
         names = _selected_variable_names(info)
 
         variables = await fetch_variables(
@@ -212,7 +206,7 @@ class Query:
             # TODO: custom exceptions
             raise ValueError(msg)
 
-        await _ensure_proposal_damnit_path(info, proposal)
+        await _ensure_damnit_path(info, proposal)
 
         snapshot = await fetch_metadata(proposal)
         return {
@@ -228,7 +222,7 @@ class Query:
         run: int,
         variable: str,
     ) -> JSON:  # FIX: # pyright: ignore[reportInvalidTypeForm]
-        await _ensure_proposal_damnit_path(info, database.proposal)
+        await _ensure_damnit_path(info, database.proposal)
         # TODO: Convert to Strawberry type
         # and make it analogous to DamitVariable; e.g. `data`
         return get_preview_data(  # FIX: # pyright: ignore[reportReturnType]

--- a/api/src/damnit_api/graphql/queries.py
+++ b/api/src/damnit_api/graphql/queries.py
@@ -9,7 +9,6 @@ from ..auth.permissions import PROPOSAL_PERMISSIONS
 from ..data import get_preview_data
 from ..db import async_table, get_session
 from ..metadata.services import _get_proposal_meta, _update_proposal_meta
-from ..utils import wrap_values
 from .metadata import fetch_metadata
 from .models import KNOWN_DTYPES, DamnitRun
 from .utils import DatabaseInput, fetch_info

--- a/api/src/damnit_api/graphql/subscriptions.py
+++ b/api/src/damnit_api/graphql/subscriptions.py
@@ -5,6 +5,7 @@ import strawberry
 from async_lru import alru_cache
 from strawberry.scalars import JSON
 
+from ..auth.permissions import PROPOSAL_PERMISSIONS
 from ..db import async_latest_rows, async_max, async_table
 from ..utils import create_map
 from .metadata import fetch_metadata
@@ -102,7 +103,7 @@ def filter_for_client(snapshot, since):
 
 @strawberry.type
 class Subscription:
-    @strawberry.subscription
+    @strawberry.subscription(permission_classes=PROPOSAL_PERMISSIONS)
     async def latest_data(
         self,
         database: DatabaseInput,

--- a/api/src/damnit_api/metadata/__init__.py
+++ b/api/src/damnit_api/metadata/__init__.py
@@ -1,6 +1,5 @@
 """Metadata context."""
 
-from . import gql
 from .routers import router
 
-__all__ = ["gql", "router"]
+__all__ = ["router"]

--- a/api/src/damnit_api/metadata/gql.py
+++ b/api/src/damnit_api/metadata/gql.py
@@ -8,6 +8,7 @@ import strawberry
 import strawberry.experimental.pydantic as st_pydantic
 
 from ..auth.models import User
+from ..auth.permissions import IsAuthenticated
 from . import models, services
 
 if TYPE_CHECKING:
@@ -30,7 +31,7 @@ class ProposalMeta:
 
 @strawberry.type
 class Query:
-    @strawberry.field
+    @strawberry.field(permission_classes=[IsAuthenticated])
     async def proposal_metadata(
         self,
         info: strawberry.Info[Context],

--- a/api/src/damnit_api/metadata/gql.py
+++ b/api/src/damnit_api/metadata/gql.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import strawberry
 import strawberry.experimental.pydantic as st_pydantic
 
+from ..auth.models import User
 from . import models, services
 
 if TYPE_CHECKING:
@@ -49,9 +50,12 @@ class Query:
 
         mymdc, session = info.context.mymdc, info.context.session
 
+        user = await User.from_oauth_user(mymdc, session, info.context.oauth_user)
+        allowed_proposal_numbers = [n for n in proposal_numbers if n in user._proposals]
+
         proposals_meta = await services._get_proposal_meta_many(
             mymdc,
-            proposal_numbers,
+            allowed_proposal_numbers,
             session,
         )
 

--- a/api/tests/graphql/conftest.py
+++ b/api/tests/graphql/conftest.py
@@ -81,8 +81,18 @@ def mocked_metadata_max(mocker):
 
 
 @pytest.fixture
+def mocked_ensure_damnit_path(mocker):
+    """Bypass the damnit_path validation; tests run without a request context."""
+    mocker.patch(
+        "damnit_api.graphql.queries._ensure_damnit_path",
+        return_value=None,
+    )
+
+
+@pytest.fixture
 def graphql_schema(
     bypass_proposal_permission,
+    mocked_ensure_damnit_path,
     mocked_metadata_variables,
     mocked_metadata_column,
     mocked_metadata_all_tags,

--- a/api/tests/graphql/conftest.py
+++ b/api/tests/graphql/conftest.py
@@ -26,6 +26,21 @@ def reset_caches():
 
 
 @pytest.fixture
+def bypass_proposal_permission(mocker):
+    """Bypass all proposal permission checks so tests focus on resolver logic."""
+    mocker.patch(
+        "damnit_api.auth.permissions.IsAuthenticated.has_permission",
+        new_callable=mocker.AsyncMock,
+        return_value=True,
+    )
+    mocker.patch(
+        "damnit_api.auth.permissions.IsProposalMember.has_permission",
+        new_callable=mocker.AsyncMock,
+        return_value=True,
+    )
+
+
+@pytest.fixture
 def mocked_metadata_variables(mocker):
     mocker.patch(
         "damnit_api.graphql.metadata.db.async_variables",
@@ -67,6 +82,7 @@ def mocked_metadata_max(mocker):
 
 @pytest.fixture
 def graphql_schema(
+    bypass_proposal_permission,
     mocked_metadata_variables,
     mocked_metadata_column,
     mocked_metadata_all_tags,

--- a/api/tests/graphql/test_queries.py
+++ b/api/tests/graphql/test_queries.py
@@ -42,11 +42,11 @@ def mocked_fetch_info(mocker):
     )
 
 
-@pytest.fixture(autouse=True)
-def mocked_proposal_auth(mocker):
-    """Bypass the proposal check; tests run without a request context."""
+@pytest.fixture
+def mocked_ensure_damnit_path(mocker):
+    """Bypass the damnit_path validation on the metadata query."""
     mocker.patch(
-        "damnit_api.graphql.queries._ensure_proposal_damnit_path",
+        "damnit_api.graphql.queries._ensure_damnit_path",
         return_value=None,
     )
 
@@ -261,7 +261,7 @@ async def test_runs_query_fetches_run_info_when_metadata_requested(
 
 
 @pytest.mark.asyncio
-async def test_metadata_query(graphql_schema):
+async def test_metadata_query(graphql_schema, mocked_ensure_damnit_path):
     query = """
         query TableMetadataQuery($proposal: String) {
           metadata(database: { proposal: $proposal })

--- a/api/tests/graphql/test_queries.py
+++ b/api/tests/graphql/test_queries.py
@@ -283,3 +283,57 @@ async def test_metadata_query(graphql_schema):
     }
     assert "(Untagged)" in metadata["tags"]
     assert "eTOF" in metadata["tags"]
+
+
+@pytest.fixture
+def graphql_schema_no_auth(
+    mocked_metadata_variables,
+    mocked_metadata_column,
+    mocked_metadata_all_tags,
+    mocked_metadata_variable_tags,
+):
+    """Schema without the bypass_proposal_permission fixture, so permission
+    checks run normally (and fail since there is no real request context)."""
+    import strawberry
+    from strawberry.schema.config import StrawberryConfig
+
+    from damnit_api.graphql.directives import lightweight
+    from damnit_api.graphql.models import SCALAR_MAP, DamnitVariable
+    from damnit_api.graphql.queries import Query
+    from damnit_api.graphql.subscriptions import Subscription
+
+    return strawberry.Schema(
+        query=Query,
+        subscription=Subscription,
+        types=[DamnitVariable],
+        directives=[lightweight],
+        config=StrawberryConfig(auto_camel_case=False, scalar_map=SCALAR_MAP),
+    )
+
+
+@pytest.mark.asyncio
+async def test_runs_unauthorized(graphql_schema_no_auth):
+    query = f"""
+        query {{
+          runs(database: {{proposal: "{PROPOSAL}"}}) {{
+            variables {{ name }}
+          }}
+        }}
+    """
+    result = await graphql_schema_no_auth.execute(query)
+
+    assert result.errors is not None
+    assert result.errors[0].message == "Authentication required."
+
+
+@pytest.mark.asyncio
+async def test_extracted_data_unauthorized(graphql_schema_no_auth):
+    query = f"""
+        query {{
+          extracted_data(database: {{proposal: "{PROPOSAL}"}}, run: 1, variable: "x")
+        }}
+    """
+    result = await graphql_schema_no_auth.execute(query)
+
+    assert result.errors is not None
+    assert result.errors[0].message == "Authentication required."

--- a/api/tests/graphql/test_queries.py
+++ b/api/tests/graphql/test_queries.py
@@ -42,14 +42,6 @@ def mocked_fetch_info(mocker):
     )
 
 
-@pytest.fixture
-def mocked_ensure_damnit_path(mocker):
-    """Bypass the damnit_path validation on the metadata query."""
-    mocker.patch(
-        "damnit_api.graphql.queries._ensure_damnit_path",
-        return_value=None,
-    )
-
 
 @pytest.mark.asyncio
 async def test_runs_query(graphql_schema, mocked_fetch_variables, mocked_fetch_info):
@@ -261,7 +253,7 @@ async def test_runs_query_fetches_run_info_when_metadata_requested(
 
 
 @pytest.mark.asyncio
-async def test_metadata_query(graphql_schema, mocked_ensure_damnit_path):
+async def test_metadata_query(graphql_schema):
     query = """
         query TableMetadataQuery($proposal: String) {
           metadata(database: { proposal: $proposal })
@@ -309,6 +301,50 @@ def graphql_schema_no_auth(
         directives=[lightweight],
         config=StrawberryConfig(auto_camel_case=False, scalar_map=SCALAR_MAP),
     )
+
+
+@pytest.fixture
+def graphql_schema_authenticated_non_member(mocker, graphql_schema_no_auth):
+    """Schema where the user is authenticated but not a proposal member."""
+    mocker.patch(
+        "damnit_api.auth.permissions.IsAuthenticated.has_permission",
+        new_callable=mocker.AsyncMock,
+        return_value=True,
+    )
+    mocker.patch(
+        "damnit_api.auth.permissions.IsProposalMember.has_permission",
+        new_callable=mocker.AsyncMock,
+        return_value=False,
+    )
+    return graphql_schema_no_auth
+
+
+@pytest.mark.asyncio
+async def test_runs_forbidden(graphql_schema_authenticated_non_member):
+    query = f"""
+        query {{
+          runs(database: {{proposal: "{PROPOSAL}"}}) {{
+            variables {{ name }}
+          }}
+        }}
+    """
+    result = await graphql_schema_authenticated_non_member.execute(query)
+
+    assert result.errors is not None
+    assert result.errors[0].message == "Access to this proposal is forbidden."
+
+
+@pytest.mark.asyncio
+async def test_extracted_data_forbidden(graphql_schema_authenticated_non_member):
+    query = f"""
+        query {{
+          extracted_data(database: {{proposal: "{PROPOSAL}"}}, run: 1, variable: "x")
+        }}
+    """
+    result = await graphql_schema_authenticated_non_member.execute(query)
+
+    assert result.errors is not None
+    assert result.errors[0].message == "Access to this proposal is forbidden."
 
 
 @pytest.mark.asyncio

--- a/api/tests/graphql/test_subscriptions.py
+++ b/api/tests/graphql/test_subscriptions.py
@@ -247,3 +247,48 @@ def test_filter_for_client_excludes_equal_timestamp():
 def test_filter_for_client_since_above_all_returns_none():
     snapshot = _snapshot({1: 100.0, 2: 200.0})
     assert filter_for_client(snapshot, since=300.0) is None
+
+
+# -----------------------------------------------------------------------------
+# Authorization
+
+
+@pytest.fixture
+def graphql_schema_no_auth(
+    mocked_metadata_variables,
+    mocked_metadata_column,
+    mocked_metadata_all_tags,
+    mocked_metadata_variable_tags,
+):
+    """Schema without bypass_proposal_permission so permission checks run."""
+    import strawberry
+    from strawberry.schema.config import StrawberryConfig
+
+    from damnit_api.graphql.directives import lightweight
+    from damnit_api.graphql.models import SCALAR_MAP, DamnitVariable
+    from damnit_api.graphql.queries import Query
+    from damnit_api.graphql.subscriptions import Subscription
+
+    return strawberry.Schema(
+        query=Query,
+        subscription=Subscription,
+        types=[DamnitVariable],
+        directives=[lightweight],
+        config=StrawberryConfig(auto_camel_case=False, scalar_map=SCALAR_MAP),
+    )
+
+
+@pytest.mark.asyncio
+async def test_latest_data_unauthorized(graphql_schema_no_auth, current_timestamp):
+    gen = await graphql_schema_no_auth.subscribe(
+        """
+        subscription {
+          latest_data(database: { proposal: "999999" }, timestamp: 0)
+        }
+        """,
+    )
+    # Subscription permission failures surface as a PreExecutionError on the
+    # first iteration rather than immediately from subscribe().
+    first = await gen.__anext__()
+    assert first.errors is not None
+    assert first.errors[0].message == "Authentication required."


### PR DESCRIPTION
PR updates gql auth/z code to use  Strawberry's 'native' permission model (classes inheriting `BasePermission`, with `permission_classes=...` on fields) instead of implicit authentication within `_ensure_proposal_damnit_path`.

Adds `IsAuthenticated` and `IsProposalMember` classes, included in `@strawberry.field(permission_classes=...)`  where appropriate.

Makes `_ensure_proposal_damnit_path` only deal with checking proposal has damnit path (removing auth/z responsibilities) and renames the function to `_ensure_damnit_path`.