### PR TITLE
ci: add API test workflow

### DIFF
--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -1,0 +1,60 @@
+name: Test API
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "api/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/test-api.yml"
+  pull_request:
+    paths:
+      - "api/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/test-api.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    defaults:
+      run:
+        working-directory: api
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.13"
+
+      - name: Sync dependencies
+        run: uv sync --locked --group test --group lint
+
+      - name: Ruff check
+        run: uv run --no-sync ruff check .
+
+      - name: Ruff format check
+        run: uv run --no-sync ruff format --check .
+
+      - name: Pytest
+        run: uv run --no-sync pytest
+        env:
+          DW_API_AUTH__CLIENT_ID: test
+          DW_API_AUTH__CLIENT_SECRET: test
+          DW_API_AUTH__SERVER_METADATA_URL: https://example.com/.well-known
+          DW_API_SESSION_SECRET: test

--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/api/scripts/reproduce-read-lock.py
+++ b/api/scripts/reproduce-read-lock.py
@@ -1,6 +1,7 @@
 """Reproduce the writer-side `database is locked` error against the
 production read path in `damnit_api.db`.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -97,6 +98,7 @@ sys.stdout.flush()
 # ---------------------------------------------------------------------------
 # Reader
 
+
 async def _single_reader(deadline):
     from damnit_api.db import (
         async_all_tags,
@@ -113,9 +115,7 @@ async def _single_reader(deadline):
     while time.monotonic() < deadline:
         try:
             await async_variables(PROPOSAL_LABEL)
-            run_variables = await async_table(
-                PROPOSAL_LABEL, name="run_variables"
-            )
+            run_variables = await async_table(PROPOSAL_LABEL, name="run_variables")
             await async_latest_rows(
                 PROPOSAL_LABEL,
                 table=run_variables,
@@ -136,9 +136,7 @@ async def _single_reader(deadline):
 
 async def reader_loop(duration, readers):
     deadline = time.monotonic() + duration
-    results = await asyncio.gather(
-        *[_single_reader(deadline) for _ in range(readers)]
-    )
+    results = await asyncio.gather(*[_single_reader(deadline) for _ in range(readers)])
     total_ops = total_locks = total_others = 0
     for ops, locks, others in results:
         total_ops += ops
@@ -149,6 +147,7 @@ async def reader_loop(duration, readers):
 
 # ---------------------------------------------------------------------------
 # Orchestration
+
 
 def stage_copy(damnit_dir, scratch_dir):
     src = damnit_dir / "runs.sqlite"
@@ -165,6 +164,7 @@ def stage_copy(damnit_dir, scratch_dir):
     # Some older sqlites lack tags/variable_tags. Create empty placeholders
     # so both branches exercise the same read path on this scratch copy.
     import sqlite3
+
     with sqlite3.connect(dst) as conn:
         conn.executescript(
             "CREATE TABLE IF NOT EXISTS tags ("

--- a/api/src/damnit_api/db.py
+++ b/api/src/damnit_api/db.py
@@ -85,15 +85,11 @@ class DatabaseSessionManager(metaclass=Registry):
 
 
 def get_session(proposal) -> AsyncSession:
-    return DatabaseSessionManager(
-        proposal
-    ).session()  # FIX: # pyright: ignore[reportReturnType]
+    return DatabaseSessionManager(proposal).session()  # FIX: # pyright: ignore[reportReturnType]
 
 
 def get_connection(proposal) -> AsyncConnection:
-    return DatabaseSessionManager(
-        proposal
-    ).connect()  # FIX: # pyright: ignore[reportReturnType]
+    return DatabaseSessionManager(proposal).connect()  # FIX: # pyright: ignore[reportReturnType]
 
 
 @alru_cache(ttl=300)
@@ -134,11 +130,7 @@ async def async_latest_rows(
         start_at = datetime.now().astimezone().timestamp()
     order_by = desc(by) if descending else by
 
-    selection = (
-        select(table)
-        .where(table.c.get(by) > start_at)
-        .order_by(order_by)
-    )
+    selection = select(table).where(table.c.get(by) > start_at).order_by(order_by)
 
     async with get_session(proposal) as session:
         result = await session.execute(selection)

--- a/api/src/damnit_api/graphql/models.py
+++ b/api/src/damnit_api/graphql/models.py
@@ -183,9 +183,7 @@ class DamnitRun:
                 entry = {"value": entry}
             dtype = cls.get_dtype(name, entry)
             value, dtype = serialize(entry["value"], dtype=dtype)
-            yield DamnitVariable(
-                name=name, value=Any(value), dtype=dtype
-            )
+            yield DamnitVariable(name=name, value=Any(value), dtype=dtype)
 
     @classmethod
     def from_db(cls, record):
@@ -193,16 +191,10 @@ class DamnitRun:
 
     @classmethod
     def resolve(cls, record):
-        out = {
-            name: None
-            for name, entry in record.items()
-            if entry is None
-        }
+        out = {name: None for name, entry in record.items() if entry is None}
         for v in cls._iter_variables(record):
             out[v.name] = (
-                None
-                if v.value is None
-                else {"value": v.value, "dtype": v.dtype.value}
+                None if v.value is None else {"value": v.value, "dtype": v.dtype.value}
             )
         return out
 

--- a/api/src/damnit_api/graphql/subscriptions.py
+++ b/api/src/damnit_api/graphql/subscriptions.py
@@ -62,15 +62,14 @@ async def poll_proposal(proposal):
             run_values.update(run_info)
 
         runs[run] = DamnitRun.resolve(run_values)
-        run_timestamps[run] = max(
-            data.timestamp for data in variables.values()
-        )
+        run_timestamps[run] = max(data.timestamp for data in variables.values())
 
     if not runs:
         return None
 
     if latest_data.timestamp is None:
-        raise ValueError("Latest data has no timestamp.")
+        msg = "Latest data has no timestamp."
+        raise ValueError(msg)
 
     _last_seen_timestamp[proposal] = latest_data.timestamp
 

--- a/api/src/damnit_api/utils.py
+++ b/api/src/damnit_api/utils.py
@@ -105,10 +105,8 @@ class Singleton(ABCMeta):
 
 class Registry(ABCMeta):
     def __call__(cls, proposal, *args, **kwargs):
-        instance = (
-            cls.registry.get(  # FIX: # pyright: ignore[reportAttributeAccessIssue]
-                proposal
-            )
+        instance = cls.registry.get(  # FIX: # pyright: ignore[reportAttributeAccessIssue]
+            proposal
         )
         if instance is None:
             instance = super().__call__(proposal, *args, **kwargs)

--- a/api/tests/test_db.py
+++ b/api/tests/test_db.py
@@ -64,6 +64,7 @@ def _open_file_descriptors_to(db_file: Path):
 # -----------------------------------------------------------------------------
 # Engine configuration
 
+
 def test_engine_uses_nullpool_and_autocommit(damnit_db):
     mgr = DatabaseSessionManager(damnit_db)
     assert isinstance(mgr._engine.pool, NullPool)
@@ -74,6 +75,7 @@ def test_engine_uses_nullpool_and_autocommit(damnit_db):
 
 # -----------------------------------------------------------------------------
 # File descriptor lifetime
+
 
 # asyncio.run() creates and tears down a fresh event loop, which is what
 # this test verifies (no file descriptors leak after the loop dies).


### PR DESCRIPTION
To finalize all the recent big PRs, we now add a CI for the API tests which runs `ruff` (linting) and `pytest` (tests).