### PR TITLE
Switch to the previous opened tab when closing a tab

### DIFF
--- a/frontend/packages/ui/src/features/dashboard/dashboard.slice.ts
+++ b/frontend/packages/ui/src/features/dashboard/dashboard.slice.ts
@@ -4,6 +4,7 @@ import { type TabItem } from '../../types'
 type MainState = {
   tabs: Record<string, TabItem>
   currentTab: string
+  previousTab?: string
 }
 
 type NavState = {
@@ -44,18 +45,33 @@ const slice = createSlice({
     // Main
     setCurrentTab: (state, action) => {
       const id = action.payload
-      if (id in state.main.tabs) {
+      if (id in state.main.tabs && id !== state.main.currentTab) {
+        state.main.previousTab = state.main.currentTab
         state.main.currentTab = id
       }
     },
     addTab: (state, action) => {
       const { id, ...rest } = action.payload
+      if (id !== state.main.currentTab) {
+        state.main.previousTab = state.main.currentTab
+      }
       state.main.currentTab = id
       state.main.tabs = Object.assign(state.main.tabs || {}, { [id]: rest })
     },
     removeTab: (state, action: PayloadAction<string>) => {
-      const { [action.payload]: _ = {}, ...rest } = state.main.tabs
-      state.main.currentTab = Object.keys(rest).slice(-1)[0]
+      const removed = action.payload
+      const { [removed]: _ = {}, ...rest } = state.main.tabs
+
+      if (state.main.currentTab === removed) {
+        const { previousTab } = state.main
+        state.main.currentTab =
+          previousTab && previousTab in rest
+            ? previousTab
+            : Object.keys(rest).slice(-1)[0]
+      }
+      if (state.main.previousTab === removed) {
+        state.main.previousTab = undefined
+      }
       state.main.tabs = rest
     },
 


### PR DESCRIPTION
Before the frontend would always switch to the last tab in the tab bar, now we track the previous tab and switch to that instead.

Written with help from Claude :robot: 