### PR TITLE
Remove the `keepMounted={false}` override for tabs

### DIFF
--- a/frontend/packages/ui/src/features/dashboard/dashboard.main.tsx
+++ b/frontend/packages/ui/src/features/dashboard/dashboard.main.tsx
@@ -83,7 +83,6 @@ const MainTabs = ({ contents, active, setActive, ...props }: TabsProps) => {
         variant="outline"
         visibleFrom="sm"
         pt={8}
-        keepMounted={false}
         {...props}
       >
         <MantineTabs.List px={8}>
@@ -138,12 +137,18 @@ function DashboardMain({ tableProps, contextFileProps }: DashBoardMainProps) {
   const main = useAppSelector((state) => state.dashboard.main)
 
   // Main tabs
+  //
+  // The editor and plots tabs stay mounted (Mantine's default keepMounted) so
+  // Monaco/Plotly keep their view state. The table instead restores its scroll
+  // position on mount (see useScrollToView), so we render it only while active
+  // and let it remount on return.
   const mainTabElements = {
-    table: (
-      <Suspense fallback={<CenteredLoader />}>
-        <Table {...tableProps} />
-      </Suspense>
-    ),
+    table:
+      main.currentTab === 'table' ? (
+        <Suspense fallback={<CenteredLoader />}>
+          <Table {...tableProps} />
+        </Suspense>
+      ) : null,
     plots: (
       <Suspense fallback={<CenteredLoader />}>
         <PlotsTab />


### PR DESCRIPTION
This was causing the Monaco state to be cleared when switching away from the context file editor, which meant that it would lose the scroll position everytime it was switched away.

Disclaimer: I don't actually know why this was set in the first place, it seems to have been introduced in https://github.com/European-XFEL/DAMNIT-web/pull/151. As far as I (*cough* Claude *cough*) can tell the only effect is to avoid the context file polling every 5s.

Written with help from Claude :robot: 