### PR TITLE
Display variable errors as colored cells in the table

### DIFF
--- a/api/src/damnit_api/graphql/models.py
+++ b/api/src/damnit_api/graphql/models.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass
+import json
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import NewType
 
@@ -6,6 +7,7 @@ import numpy as np
 import strawberry
 from damnit.api import blob2complex
 
+from .. import get_logger
 from ..shared.const import DamnitType
 from ..utils import (
     b64image,
@@ -14,6 +16,8 @@ from ..utils import (
     python_type_to_damnit_type,
     summary_type_to_damnit_type,
 )
+
+logger = get_logger()
 
 
 @dataclass(frozen=True)
@@ -157,10 +161,44 @@ strawberry.enum(DamnitType, graphql_name_from="value")
 
 
 @strawberry.type
+class DamnitVariableError:
+    message: str
+    cls: str
+
+    @classmethod
+    def from_attrs(cls, attributes):
+        """Pull the error out of a `run_variables.attributes` value.
+
+        When a variable fails to execute, DAMNIT stores a JSON string like
+        ``{"error": "...", "error_cls": "..."}`` in the `attributes` column.
+        Returns a `DamnitVariableError`, or None if there is no error.
+        """
+        if not isinstance(attributes, str):
+            return None
+        try:
+            attributes = json.loads(attributes)
+        except ValueError:
+            logger.error(
+                "Failed to parse run_variables.attributes JSON: %r", attributes
+            )
+            return None
+        if not isinstance(attributes, dict):
+            return None
+
+        message = attributes.get("error")
+        error_cls = attributes.get("error_cls")
+        if isinstance(message, str) and isinstance(error_cls, str):
+            return cls(message=message, cls=error_cls)
+
+        return None
+
+
+@strawberry.type
 class DamnitVariable:
     name: str
     value: Any | None
     dtype: DamnitType
+    error: DamnitVariableError | None = None
 
 
 @strawberry.type
@@ -183,7 +221,8 @@ class DamnitRun:
                 entry = {"value": entry}
             dtype = cls.get_dtype(name, entry)
             value, dtype = serialize(entry["value"], dtype=dtype)
-            yield DamnitVariable(name=name, value=Any(value), dtype=dtype)
+            error = DamnitVariableError.from_attrs(entry.get("attributes"))
+            yield DamnitVariable(name=name, value=Any(value), dtype=dtype, error=error)
 
     @classmethod
     def from_db(cls, record):
@@ -191,11 +230,20 @@ class DamnitRun:
 
     @classmethod
     def resolve(cls, record):
-        out = {name: None for name, entry in record.items() if entry is None}
+        out: dict[str, object | None] = {
+            name: None for name, entry in record.items() if entry is None
+        }
+
         for v in cls._iter_variables(record):
-            out[v.name] = (
-                None if v.value is None else {"value": v.value, "dtype": v.dtype.value}
-            )
+            if v.value is None and v.error is None:
+                out[v.name] = None
+                continue
+
+            resolved = {"value": v.value, "dtype": v.dtype.value}
+            if v.error is not None:
+                resolved["error"] = asdict(v.error)
+
+            out[v.name] = resolved
         return out
 
     @staticmethod

--- a/api/src/damnit_api/graphql/queries.py
+++ b/api/src/damnit_api/graphql/queries.py
@@ -62,6 +62,7 @@ def group_by_run(record):
         grouped[key][entry["name"]] = {
             "value": entry["value"],
             "summary_type": entry["summary_type"],
+            "attributes": entry["attributes"],
         }
 
     return list(grouped.values())
@@ -104,6 +105,7 @@ async def fetch_variables(proposal, *, limit, offset, names=None):
             latest_timestamp_subquery.c.name,
             table.c.value,
             table.c.summary_type,
+            table.c.attributes,
         )
         .select_from(runs_subquery)
         .outerjoin(

--- a/api/src/damnit_api/graphql/subscriptions.py
+++ b/api/src/damnit_api/graphql/subscriptions.py
@@ -53,7 +53,11 @@ async def poll_proposal(proposal):
     run_timestamps = {}
     for run, variables in latest_data.runs.items():
         run_values = {
-            name: {"value": data.value, "summary_type": data.summary_type}
+            name: {
+                "value": data.value,
+                "summary_type": data.summary_type,
+                "attributes": data.attributes,
+            }
             for name, data in variables.items()
         }
         run_values.setdefault("run", {"value": run})

--- a/api/src/damnit_api/graphql/utils.py
+++ b/api/src/damnit_api/graphql/utils.py
@@ -24,6 +24,7 @@ class MetaData:
 class Data(MetaData):
     value: Any = None
     summary_type: str | None = None
+    attributes: str | None = None
 
 
 class LatestData:
@@ -40,6 +41,7 @@ class LatestData:
             run[data["name"]] = Data(
                 value=data["value"],
                 summary_type=data.get("summary_type"),
+                attributes=data.get("attributes"),
                 timestamp=timestamp,
             )
 

--- a/api/tests/graphql/test_models.py
+++ b/api/tests/graphql/test_models.py
@@ -1,9 +1,12 @@
 import io
+import json
 
 import numpy as np
 import pytest
 
 from damnit_api.graphql.models import (
+    DamnitRun,
+    DamnitVariableError,
     resample_array,
     serialize,
     to_complex_string,
@@ -135,3 +138,49 @@ def test_serialize_image():
     value, dtype = serialize(b"\x89PNG\r\n", dtype=DamnitType.IMAGE)
     assert dtype == DamnitType.IMAGE
     assert value.startswith("data:image/png;base64,")
+
+
+# -----------------------------------------------------------------------------
+# Test DamnitVariableError.from_attrs
+
+ERROR_ATTRS = {"error": "IndexError: list index out of range", "error_cls": "Foo"}
+
+
+def test_extract_error_from_json_string():
+    error = DamnitVariableError.from_attrs(json.dumps(ERROR_ATTRS))
+    assert error == DamnitVariableError(message=ERROR_ATTRS["error"], cls="Foo")
+
+
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        None,
+        {"error": "boom", "error_cls": "Foo"},
+        "not json",
+        "123",
+        "{}",
+        '{"error": "boom"}',
+        '{"error": "boom", "error_cls": 42}',
+    ],
+)
+def test_extract_error_returns_none(attributes):
+    assert DamnitVariableError.from_attrs(attributes) is None
+
+
+# -----------------------------------------------------------------------------
+# Test DamnitRun error path
+
+
+def test_resolve_includes_error_for_failed_variable():
+    record = {
+        "run": {"value": 1},
+        "broken": {"value": None, "attributes": json.dumps(ERROR_ATTRS)},
+    }
+    resolved = DamnitRun.resolve(record)
+
+    assert "error" not in resolved["run"]
+    assert resolved["broken"]["value"] is None
+    assert resolved["broken"]["error"] == {
+        "message": ERROR_ATTRS["error"],
+        "cls": "Foo",
+    }

--- a/api/tests/graphql/test_queries.py
+++ b/api/tests/graphql/test_queries.py
@@ -150,6 +150,7 @@ async def real_damnit_db(mocker, tmp_path):
                 "  name TEXT NOT NULL,"
                 "  value BLOB,"
                 "  summary_type TEXT,"
+                "  attributes BLOB,"
                 "  timestamp REAL NOT NULL,"
                 "  PRIMARY KEY (proposal, run, name, timestamp)"
                 ")"

--- a/frontend/packages/ui/src/data/table/table-data.services.ts
+++ b/frontend/packages/ui/src/data/table/table-data.services.ts
@@ -13,7 +13,11 @@ import {
   type TableMetadataOptions,
 } from './table-data.types'
 import { client } from '../../graphql/apollo'
-import { type VariableDataItem, type VariableValue } from '../../types'
+import {
+  type VariableDataItem,
+  type VariableError,
+  type VariableValue,
+} from '../../types'
 import { isEmpty } from '../../utils/helpers'
 
 /*
@@ -41,6 +45,10 @@ const buildTableDataQuery = (
         name
         value
         dtype
+        error {
+          message
+          cls
+        }
       }
     }
   }
@@ -60,6 +68,7 @@ type DamnitVariable = {
   name: string
   value: VariableValue
   dtype: string
+  error?: VariableError | null
 }
 
 type DamnitRun = {
@@ -80,6 +89,7 @@ export function flattenRuns(runs: DamnitRun[]): TableData {
       row[variable.name] = {
         value: variable.value,
         dtype: variable.dtype,
+        error: variable.error ?? undefined,
       }
     }
 

--- a/frontend/packages/ui/src/data/table/table-data.thunks.ts
+++ b/frontend/packages/ui/src/data/table/table-data.thunks.ts
@@ -30,7 +30,10 @@ export const getDeferredTable =
       ...new Set(
         Object.values(data).flatMap((run) =>
           Object.entries(run)
-            .filter(([_, variables]) => variables?.value === null)
+            .filter(
+              ([_, variables]) =>
+                variables?.value === null && variables?.error == null
+            )
             .map(([variable]) => variable)
         )
       ),

--- a/frontend/packages/ui/src/features/table/assets/error-error.svg
+++ b/frontend/packages/ui/src/features/table/assets/error-error.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#FA5252" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 9v4" />
+  <path d="M10.363 3.591l-8.106 13.534a1.914 1.914 0 0 0 1.636 2.871h16.214a1.914 1.914 0 0 0 1.636 -2.87l-8.106 -13.536a1.914 1.914 0 0 0 -3.274 0z" />
+  <path d="M12 16h.01" />
+</svg>

--- a/frontend/packages/ui/src/features/table/assets/error-missing.svg
+++ b/frontend/packages/ui/src/features/table/assets/error-missing.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#ADB5BD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+  <path d="M12 17l0 .01" />
+  <path d="M12 13.5a1.5 1.5 0 0 1 1 -1.5a2.6 2.6 0 1 0 -3 -4" />
+</svg>

--- a/frontend/packages/ui/src/features/table/assets/error-skipped.svg
+++ b/frontend/packages/ui/src/features/table/assets/error-skipped.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#ADB5BD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 9l3 3l-3 3" />
+  <path d="M13 9l3 3l-3 3" />
+  <path d="M3 12a9 9 0 1 0 0 -.265l0 .265z" />
+</svg>

--- a/frontend/packages/ui/src/features/table/cells.ts
+++ b/frontend/packages/ui/src/features/table/cells.ts
@@ -1,6 +1,8 @@
 import {
   GridCellKind,
   type BaseGridCell,
+  type CustomCell,
+  type CustomRenderer,
   type GridCell,
   type ImageCell,
   type Item,
@@ -11,8 +13,15 @@ import {
 import { type SparklineCellType } from '@glideapps/glide-data-grid-cells'
 
 import { DTYPES } from '../../constants'
-import { type VariableValue } from '../../types'
+import { type VariableError, type VariableValue } from '../../types'
 import { formatDate, formatNumber } from '../../utils/helpers'
+import errorErrorIcon from './assets/error-error.svg?url'
+import errorMissingIcon from './assets/error-missing.svg?url'
+import errorSkippedIcon from './assets/error-skipped.svg?url'
+
+// Width of the small skeleton/error box, shared by loadingCell and
+// errorCellRenderer so a no-data cell and an errored cell line up.
+const SKELETON_BOX_WIDTH = 30
 
 // TODO: Handle nonconforming data type
 
@@ -117,6 +126,83 @@ export const dateCell = (
   }
 }
 
+// Shown for variables that failed to execute (the run_variables row carries an
+// `error` instead of a value). Rendered as a small right-aligned glyph that
+// varies with the kind of error.
+const ERROR_CELL_KIND = 'error-cell'
+
+export interface ErrorCellProps {
+  readonly kind: typeof ERROR_CELL_KIND
+  readonly error: VariableError
+}
+
+export type ErrorCell = CustomCell<ErrorCellProps>
+
+export type ErrorKind = 'skipped' | 'missing' | 'error'
+
+export interface ErrorVisuals {
+  kind: ErrorKind
+  title: string
+  icon: HTMLImageElement
+}
+
+const ERROR_META: Record<ErrorKind, { title: string; src: string }> = {
+  skipped: { title: 'Missing dependency', src: errorSkippedIcon },
+  missing: { title: 'Missing data', src: errorMissingIcon },
+  error: { title: 'Error', src: errorErrorIcon },
+}
+
+const errorIconCache = new Map<ErrorKind, HTMLImageElement>()
+
+// Resolve an exception class to its display kind, title and (cached) icon.
+export const errorVisuals = (cls: string): ErrorVisuals => {
+  const kind: ErrorKind =
+    cls === 'Skip' ? 'skipped' : cls === 'SourceNameError' ? 'missing' : 'error'
+
+  let icon = errorIconCache.get(kind)
+  if (!icon) {
+    icon = new Image()
+    icon.src = ERROR_META[kind].src
+    errorIconCache.set(kind, icon)
+  }
+
+  return { kind, title: ERROR_META[kind].title, icon }
+}
+
+// Clipboard/copy representation, shared by the cell's copyData and the
+// tooltip's Ctrl+C handler.
+export const errorText = (error: VariableError): string =>
+  `${error.cls}\n${error.message}`
+
+export const errorCell = (
+  error: VariableError,
+  params: Partial<BaseGridCell> = {}
+): ErrorCell => {
+  return {
+    kind: GridCellKind.Custom,
+    allowOverlay: false,
+    copyData: errorText(error),
+    data: { kind: ERROR_CELL_KIND, error },
+    ...params,
+  }
+}
+
+export const errorCellRenderer: CustomRenderer<ErrorCell> = {
+  kind: GridCellKind.Custom,
+  isMatch: (cell: CustomCell): cell is ErrorCell =>
+    (cell.data as Partial<ErrorCellProps>).kind === ERROR_CELL_KIND,
+  draw: ({ ctx, rect, theme, cell }) => {
+    const img = errorVisuals(cell.data.error.cls).icon
+    if (!img.complete || img.naturalWidth === 0) return
+
+    const size = Math.min(20, rect.height - 2 * theme.cellVerticalPadding)
+    const x = rect.x + rect.width - theme.cellHorizontalPadding - size
+    const y = rect.y + (rect.height - size) / 2
+
+    ctx.drawImage(img, x, y, size, size)
+  },
+}
+
 export const loadingCell = (
   _: VariableValue,
   params: Partial<BaseGridCell> = {}
@@ -124,7 +210,7 @@ export const loadingCell = (
   return {
     kind: GridCellKind.Loading,
     allowOverlay: false,
-    skeletonWidth: 30,
+    skeletonWidth: SKELETON_BOX_WIDTH,
     skeletonHeight: 30,
     ...params,
   }

--- a/frontend/packages/ui/src/features/table/components/error-tooltip.tsx
+++ b/frontend/packages/ui/src/features/table/components/error-tooltip.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  ActionIcon,
+  Group,
+  ScrollArea,
+  Text,
+  Tooltip,
+  useComputedColorScheme,
+  useMantineTheme,
+} from '@mantine/core'
+import { IconCheck, IconCopy } from '@tabler/icons-react'
+import { Arrow, type LayerProps, type UseLayerArrowProps } from 'react-laag'
+
+import { type VariableError } from '../../../types'
+import { errorText, errorVisuals } from '../cells'
+
+export type ErrorTooltipProps = {
+  error: VariableError
+  layerProps: LayerProps
+  arrowProps: UseLayerArrowProps
+  onMouseEnter: () => void
+  onMouseLeave: () => void
+}
+
+const COPIED_RESET_MS = 1500
+
+export const ErrorTooltip = ({
+  error,
+  layerProps,
+  arrowProps,
+  onMouseEnter,
+  onMouseLeave,
+}: ErrorTooltipProps) => {
+  const { kind, title } = errorVisuals(error.cls)
+  const accent = kind === 'error' ? 'red.4' : 'gray.4'
+  const [copied, setCopied] = useState(false)
+  const resetTimerRef = useRef<number>(0)
+  const theme = useMantineTheme()
+  const scheme = useComputedColorScheme('light')
+  const surfaceColor =
+    scheme === 'dark' ? theme.colors.dark[5] : theme.colors.dark[7]
+
+  useEffect(() => {
+    window.clearTimeout(resetTimerRef.current)
+    setCopied(false)
+    return () => {
+      window.clearTimeout(resetTimerRef.current)
+    }
+  }, [error])
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(errorText(error)).then(() => {
+      setCopied(true)
+      window.clearTimeout(resetTimerRef.current)
+      resetTimerRef.current = window.setTimeout(
+        () => setCopied(false),
+        COPIED_RESET_MS
+      )
+    })
+  }
+
+  const { ref: layerRef, style: layerStyle } = layerProps
+
+  return (
+    <div
+      ref={layerRef}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={{
+        ...layerStyle,
+        maxWidth: 360,
+        background: surfaceColor,
+        color: 'var(--mantine-color-white)',
+        borderRadius: 6,
+        padding: '8px 10px',
+        boxShadow:
+          '0 0 0 1px var(--mantine-color-default-border), var(--mantine-shadow-md)',
+      }}
+    >
+      <Arrow
+        {...arrowProps}
+        backgroundColor={surfaceColor}
+        borderWidth={0}
+        size={10}
+      />
+      <Group justify="space-between" gap="md" wrap="nowrap" mb={4}>
+        <div>
+          <Text size="xs" fw={700} c={accent}>
+            {title}
+          </Text>
+          <Text size="xs" c="gray.5" style={{ fontFamily: 'monospace' }}>
+            {error.cls}
+          </Text>
+        </div>
+        <Tooltip
+          label={copied ? 'Copied' : 'Copy'}
+          withArrow
+          styles={{ tooltip: { fontSize: 10, padding: '2px 6px' } }}
+        >
+          <ActionIcon
+            variant="subtle"
+            color="gray"
+            size="sm"
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <IconCheck size={14} color="var(--mantine-color-teal-4)" />
+            ) : (
+              <IconCopy size={14} />
+            )}
+          </ActionIcon>
+        </Tooltip>
+      </Group>
+      <ScrollArea.Autosize mah={200} type="auto">
+        <Text
+          size="xs"
+          style={{ whiteSpace: 'pre-wrap', fontFamily: 'monospace' }}
+        >
+          {error.message}
+        </Text>
+      </ScrollArea.Autosize>
+    </div>
+  )
+}

--- a/frontend/packages/ui/src/features/table/hooks/use-error-tooltip.tsx
+++ b/frontend/packages/ui/src/features/table/hooks/use-error-tooltip.tsx
@@ -1,0 +1,248 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { type GridMouseEventArgs } from '@glideapps/glide-data-grid'
+import { type IBounds, useLayer } from 'react-laag'
+
+import { ErrorTooltip } from '../components/error-tooltip'
+
+import { type VariableError } from '../../../types'
+
+type TooltipState = { error: VariableError; bounds: IBounds }
+
+const ZERO_BOUNDS: IBounds = {
+  left: 0,
+  top: 0,
+  width: 0,
+  height: 0,
+  right: 0,
+  bottom: 0,
+}
+
+const CLOSE_GRACE_MS = 1000
+const OPEN_DWELL_MS = 500
+const TRIGGER_OFFSET = 8
+const ICON_SIZE = 20
+const ICON_PADDING = 8
+// 10px tooltip right padding + 26/2 ActionIcon(sm), so `bottom-end` lands
+// the Copy button on the icon column.
+const COPY_BUTTON_RIGHT_INSET = 23
+
+const sameTarget = (
+  a: TooltipState | null | undefined,
+  b: TooltipState
+): boolean =>
+  !!a &&
+  a.error === b.error &&
+  a.bounds.left === b.bounds.left &&
+  a.bounds.top === b.bounds.top
+
+export const useErrorTooltip = (
+  lookupError: (col: number, row: number) => VariableError | undefined
+) => {
+  const [tooltip, setTooltip] = useState<TooltipState>()
+  const tooltipRef = useRef<TooltipState | undefined>(tooltip)
+  const closeTimerRef = useRef<number>(0)
+  const openTimerRef = useRef<number>(0)
+  const rehoverFrameRef = useRef<number>(0)
+  const pendingTargetRef = useRef<TooltipState | null>(null)
+  const engagedRef = useRef(false)
+  const cursorRef = useRef<{ x: number; y: number } | null>(null)
+
+  useLayoutEffect(() => {
+    tooltipRef.current = tooltip
+  }, [tooltip])
+
+  useEffect(() => {
+    const onMove = (event: MouseEvent) => {
+      cursorRef.current = { x: event.clientX, y: event.clientY }
+    }
+    window.addEventListener('mousemove', onMove, { passive: true })
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+    }
+  }, [])
+
+  const cancelClose = useCallback(() => {
+    window.clearTimeout(closeTimerRef.current)
+  }, [])
+
+  const scheduleClose = useCallback(() => {
+    window.clearTimeout(closeTimerRef.current)
+    closeTimerRef.current = window.setTimeout(() => {
+      engagedRef.current = false
+      setTooltip(undefined)
+    }, CLOSE_GRACE_MS)
+  }, [])
+
+  const cancelOpen = useCallback(() => {
+    window.clearTimeout(openTimerRef.current)
+    pendingTargetRef.current = null
+  }, [])
+
+  const scheduleOpen = useCallback((target: TooltipState) => {
+    window.clearTimeout(openTimerRef.current)
+    if (engagedRef.current) {
+      pendingTargetRef.current = null
+      setTooltip(target)
+      return
+    }
+    pendingTargetRef.current = target
+    openTimerRef.current = window.setTimeout(() => {
+      pendingTargetRef.current = null
+      setTooltip(target)
+    }, OPEN_DWELL_MS)
+  }, [])
+
+  const dismiss = useCallback(() => {
+    cancelOpen()
+    cancelClose()
+    engagedRef.current = false
+    setTooltip(undefined)
+  }, [cancelClose, cancelOpen])
+
+  // Glide doesn't refire hover after a layout shift. Wait one frame for
+  // the tooltip portal to unmount, then dispatch a synthetic mousemove
+  // so Glide re-evaluates which cell is under the cursor.
+  const rehoverAtCursor = useCallback(() => {
+    const cursor = cursorRef.current
+    if (!cursor) {
+      return
+    }
+    cancelAnimationFrame(rehoverFrameRef.current)
+    rehoverFrameRef.current = requestAnimationFrame(() => {
+      const target = document.elementFromPoint(cursor.x, cursor.y)
+      if (!target) {
+        return
+      }
+      target.dispatchEvent(
+        new MouseEvent('mousemove', {
+          clientX: cursor.x,
+          clientY: cursor.y,
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        })
+      )
+    })
+  }, [])
+
+  const dismissOnScroll = useCallback(() => {
+    dismiss()
+    rehoverAtCursor()
+  }, [dismiss, rehoverAtCursor])
+
+  const onBodyEnter = useCallback(() => {
+    engagedRef.current = true
+    cancelOpen()
+    cancelClose()
+  }, [cancelClose, cancelOpen])
+
+  const onBodyLeave = useCallback(() => {
+    scheduleClose()
+  }, [scheduleClose])
+
+  const onItemHovered = useCallback(
+    (args: GridMouseEventArgs) => {
+      if (args.kind !== 'cell') {
+        cancelOpen()
+        scheduleClose()
+        return
+      }
+      const [col, row] = args.location
+      const error = lookupError(col, row)
+      if (!error) {
+        cancelOpen()
+        scheduleClose()
+        return
+      }
+      cancelClose()
+      const iconCenterX =
+        args.bounds.x + args.bounds.width - ICON_PADDING - ICON_SIZE / 2
+      const target: TooltipState = {
+        error,
+        bounds: {
+          left: iconCenterX - COPY_BUTTON_RIGHT_INSET,
+          top: args.bounds.y,
+          width: COPY_BUTTON_RIGHT_INSET * 2,
+          height: args.bounds.height,
+          right: iconCenterX + COPY_BUTTON_RIGHT_INSET,
+          bottom: args.bounds.y + args.bounds.height,
+        },
+      }
+      if (sameTarget(tooltipRef.current, target)) {
+        cancelOpen()
+        return
+      }
+      if (sameTarget(pendingTargetRef.current, target)) {
+        return
+      }
+      scheduleOpen(target)
+    },
+    [lookupError, cancelClose, cancelOpen, scheduleClose, scheduleOpen]
+  )
+
+  useEffect(
+    () => () => {
+      window.clearTimeout(closeTimerRef.current)
+      window.clearTimeout(openTimerRef.current)
+      cancelAnimationFrame(rehoverFrameRef.current)
+    },
+    []
+  )
+
+  useEffect(() => {
+    if (!tooltip) {
+      return
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        dismiss()
+      }
+    }
+    // Capture phase: Glide's hidden input swallows keydown in the bubble phase.
+    window.addEventListener('keydown', handleKeyDown, { capture: true })
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, { capture: true })
+    }
+  }, [tooltip, dismiss])
+
+  // Stable identity so react-laag does not re-subscribe scroll/resize
+  // listeners on every render.
+  const trigger = useMemo(
+    () => ({ getBounds: () => tooltipRef.current?.bounds ?? ZERO_BOUNDS }),
+    []
+  )
+
+  const { renderLayer, layerProps, arrowProps } = useLayer({
+    isOpen: tooltip !== undefined,
+    placement: 'bottom-end',
+    possiblePlacements: ['bottom-end', 'top-end', 'bottom-start', 'top-start'],
+    auto: true,
+    triggerOffset: TRIGGER_OFFSET,
+    container: 'portal',
+    trigger,
+  })
+
+  return {
+    onItemHovered,
+    dismiss,
+    dismissOnScroll,
+    tooltip: tooltip
+      ? renderLayer(
+          <ErrorTooltip
+            error={tooltip.error}
+            layerProps={layerProps}
+            arrowProps={arrowProps}
+            onMouseEnter={onBodyEnter}
+            onMouseLeave={onBodyLeave}
+          />
+        )
+      : null,
+  }
+}

--- a/frontend/packages/ui/src/features/table/table.tsx
+++ b/frontend/packages/ui/src/features/table/table.tsx
@@ -13,10 +13,17 @@ import {
 import { allCells } from '@glideapps/glide-data-grid-cells'
 import { Group, Stack } from '@mantine/core'
 
-import { getCell, numberCell, textCell } from './cells'
+import {
+  errorCell,
+  errorCellRenderer,
+  getCell,
+  numberCell,
+  textCell,
+} from './cells'
 import { TagsPopover } from './components/popovers/tags-popover'
 import { VariablesPopover } from './components/popovers/variables-popover'
 import ContextMenu from './context-menu'
+import { useErrorTooltip } from './hooks/use-error-tooltip'
 import { useTable } from './hooks/use-table'
 import { useContextMenu } from './use-context-menu'
 import { usePagination } from './use-pagination'
@@ -31,6 +38,8 @@ import { getTableData } from '../../data/table'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { isArrayEqual, sorted } from '../../utils/array'
 import { isEmpty } from '../../utils/helpers'
+
+const CUSTOM_RENDERERS = [...allCells, errorCellRenderer]
 
 type Column = {
   id: string
@@ -103,6 +112,11 @@ const Table = ({ grid, paginated = true }: TableProps) => {
         return textCell('')
       }
 
+      const cellError = rowData[variable].error
+      if (cellError) {
+        return errorCell(cellError)
+      }
+
       return getCell({
         value: rowData[variable].value,
         dtype: rowData[variable].dtype,
@@ -111,6 +125,23 @@ const Table = ({ grid, paginated = true }: TableProps) => {
     },
     [tableColumns, tableMetadata.runs, tableData, tableLastUpdate]
   )
+
+  // Cell: Error tooltip (shown when hovering an errored variable's cell).
+  const lookupError = useCallback(
+    (col: number, row: number) => {
+      const run = tableMetadata.runs[row]
+      const variable = tableColumns[col]?.id
+      return run != null && variable
+        ? tableData[run]?.[variable]?.error
+        : undefined
+    },
+    [tableColumns, tableMetadata.runs, tableData]
+  )
+  const {
+    onItemHovered: handleItemHovered,
+    dismissOnScroll: dismissErrorTooltipOnScroll,
+    tooltip: errorTooltip,
+  } = useErrorTooltip(lookupError)
 
   // Cell: Click event
   const [gridSelection, setGridSelection] = useState<GridSelection>({
@@ -329,12 +360,31 @@ const Table = ({ grid, paginated = true }: TableProps) => {
     })
   }
 
-  const handleVisibleRegionchange = useCallback(
-    (rect: Rectangle) => {
+  const lastVisibleRegionRef = useRef<{
+    rect: Rectangle
+    tx: number
+    ty: number
+  } | null>(null)
+  const handleVisibleRegionChange = useCallback(
+    (rect: Rectangle, tx?: number, ty?: number) => {
       paginationHandler(rect)
       scrollToViewHandler(rect)
+      const previous = lastVisibleRegionRef.current
+      const nextTx = tx ?? 0
+      const nextTy = ty ?? 0
+      // tx/ty catch sub-cell smooth-scroll where rect.x/y stay unchanged.
+      const scrolled =
+        !previous ||
+        previous.rect.x !== rect.x ||
+        previous.rect.y !== rect.y ||
+        previous.tx !== nextTx ||
+        previous.ty !== nextTy
+      lastVisibleRegionRef.current = { rect, tx: nextTx, ty: nextTy }
+      if (scrolled) {
+        dismissErrorTooltipOnScroll()
+      }
     },
-    [paginationHandler, scrollToViewHandler]
+    [paginationHandler, scrollToViewHandler, dismissErrorTooltipOnScroll]
   )
 
   return (
@@ -360,12 +410,14 @@ const Table = ({ grid, paginated = true }: TableProps) => {
               rangeSelect="multi-cell"
               onCellContextMenu={handleCellContextMenu}
               onHeaderContextMenu={handleHeaderContextMenu}
+              onItemHovered={handleItemHovered}
               freezeColumns={1}
-              customRenderers={allCells}
-              onVisibleRegionChanged={handleVisibleRegionchange}
+              customRenderers={CUSTOM_RENDERERS}
+              onVisibleRegionChanged={handleVisibleRegionChange}
               scrollOffsetX={scrollX}
               scrollOffsetY={scrollY}
             />
+            {errorTooltip}
             <ContextMenu {...contextMenu} />
             <div id="portal" />
           </>

--- a/frontend/packages/ui/src/svg.d.ts
+++ b/frontend/packages/ui/src/svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg?url' {
+  const url: string
+  export default url
+}

--- a/frontend/packages/ui/src/types.ts
+++ b/frontend/packages/ui/src/types.ts
@@ -9,9 +9,15 @@ export type DeepPartial<T> = T extends Function
 
 export type VariableValue = Maybe<string | number | number[]>
 
+export type VariableError = {
+  message: string
+  cls: string
+}
+
 export type VariableDataItem = {
   value: VariableValue
   dtype: string
+  error?: VariableError
 }
 
 export type VariableMetadataItem = {


### PR DESCRIPTION
I foolishly thought this would be simple, but it was not:
<img width="1433" height="871" alt="attributes" src="https://github.com/user-attachments/assets/9d85f16d-2fb8-4efa-9b56-b67aaaf94f72" />

It's hard for me to say how good the code style is, but as far as I can understand it's not *too* terrible. I initially had a copy button in the tooltip, but it ended up being a bit janky when moving the mouse around the table and not interfering with displaying errors from other cells, so I opted to go for hotkeys instead.

Written with help from Claude :robot: 