### PR TITLE
feat(frontend/context-file): persist Monaco editor view state

### DIFF
--- a/frontend/apps/app/src/app.tsx
+++ b/frontend/apps/app/src/app.tsx
@@ -22,6 +22,7 @@ import {
   PrivateRoute,
   Proposals,
   history,
+  resetContextFile,
   resetDashboard,
   resetExtractedData,
   resetMetadata,
@@ -52,6 +53,7 @@ function ProposalWrapper({ children }: PropsWithChildren) {
       dispatch(resetPlots())
       dispatch(resetMetadata())
       dispatch(resetDashboard())
+      dispatch(resetContextFile())
     }
   }, [proposal_number, dispatch])
 

--- a/frontend/apps/demo/src/routes/example/route.tsx
+++ b/frontend/apps/demo/src/routes/example/route.tsx
@@ -3,6 +3,7 @@ import { useLoaderData } from 'react-router'
 
 import {
   NotFoundPage,
+  resetContextFile,
   resetExtractedData,
   resetMetadata,
   resetPlots,
@@ -33,6 +34,7 @@ function ExampleRoute() {
       dispatch(resetExtractedData())
       dispatch(resetPlots())
       dispatch(resetMetadata())
+      dispatch(resetContextFile())
     }
   }, [info?.id, dispatch])
 

--- a/frontend/packages/ui/src/auth/auth.thunks.ts
+++ b/frontend/packages/ui/src/auth/auth.thunks.ts
@@ -3,6 +3,7 @@ import { authApi } from './auth.api'
 import { HTTP_URL } from '../constants'
 import { resetExtractedData } from '../data/extracted'
 import { resetTable as resetTableData } from '../data/table'
+import { resetContextFile } from '../features/context-file'
 import { resetTable as resetTableView } from '../features/table'
 import { resetPlots } from '../features/plots'
 import { type AppThunk } from '../redux/thunks'
@@ -30,6 +31,7 @@ export const logout = (): AppThunk => (dispatch) => {
         dispatch(resetTableView())
         dispatch(resetExtractedData())
         dispatch(resetPlots())
+        dispatch(resetContextFile())
 
         dispatch(authApi.util.resetApiState())
 

--- a/frontend/packages/ui/src/features/context-file/context-file-editor.tsx
+++ b/frontend/packages/ui/src/features/context-file/context-file-editor.tsx
@@ -1,12 +1,40 @@
-import { Editor as Monaco } from '@monaco-editor/react'
+import { useLayoutEffect, useRef } from 'react'
+import { Editor as Monaco, type OnMount } from '@monaco-editor/react'
 
 import { CenteredLoader } from '../../components/feedback'
+import { useAppDispatch, useAppStore } from '../../redux/hooks'
+import { setView } from './context-file.slice'
+
+type MonacoEditor = Parameters<OnMount>[0]
 
 interface ContextFileEditorProps {
   content?: string
 }
 
 const ContextFileEditor = ({ content }: ContextFileEditorProps) => {
+  const dispatch = useAppDispatch()
+  const store = useAppStore()
+  const editorRef = useRef<MonacoEditor | null>(null)
+
+  const handleMount: OnMount = (editor) => {
+    editorRef.current = editor
+    const savedView = store.getState().contextFile.view
+    if (savedView) {
+      editor.restoreViewState(savedView)
+    }
+  }
+
+  // Save the view state in a layout-effect cleanup to avoid race with a parent
+  // useEffect cleanup (e.g. resetContextFile on proposal change).
+  useLayoutEffect(() => {
+    return () => {
+      const viewState = editorRef.current?.saveViewState()
+      if (viewState) {
+        dispatch(setView(viewState))
+      }
+    }
+  }, [dispatch])
+
   return (
     <Monaco
       theme="vs-light"
@@ -23,6 +51,7 @@ const ContextFileEditor = ({ content }: ContextFileEditorProps) => {
       defaultLanguage="python"
       value={content}
       loading={<CenteredLoader />}
+      onMount={handleMount}
     />
   )
 }

--- a/frontend/packages/ui/src/features/context-file/context-file.slice.ts
+++ b/frontend/packages/ui/src/features/context-file/context-file.slice.ts
@@ -1,0 +1,26 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { OnMount } from '@monaco-editor/react'
+
+type EditorView = ReturnType<Parameters<OnMount>[0]['saveViewState']>
+
+type ContextFileState = {
+  view: EditorView
+}
+
+const initialState: ContextFileState = {
+  view: null,
+}
+
+const slice = createSlice({
+  name: 'contextFile',
+  initialState,
+  reducers: {
+    reset: () => initialState,
+    setView: (state, action: PayloadAction<EditorView>) => {
+      state.view = action.payload
+    },
+  },
+})
+
+export default slice.reducer
+export const { reset, setView } = slice.actions

--- a/frontend/packages/ui/src/features/context-file/index.ts
+++ b/frontend/packages/ui/src/features/context-file/index.ts
@@ -1,1 +1,5 @@
 export { default as ContextFile, type ContextFileProps } from './context-file'
+export {
+  default as contextFileReducer,
+  reset as resetContextFile,
+} from './context-file.slice'

--- a/frontend/packages/ui/src/index.ts
+++ b/frontend/packages/ui/src/index.ts
@@ -22,6 +22,7 @@ export {
   LoggedOutPage,
   NotFoundPage,
 } from './features/pages'
+export { resetContextFile } from './features/context-file'
 export { resetPlots } from './features/plots'
 export { Proposals } from './features/proposals'
 export { resetTable as resetTableView } from './features/table'

--- a/frontend/packages/ui/src/redux/reducer.ts
+++ b/frontend/packages/ui/src/redux/reducer.ts
@@ -2,6 +2,7 @@ import { combineReducers } from '@reduxjs/toolkit'
 
 import { authApi } from '../auth'
 
+import { contextFileReducer as contextFile } from '../features/context-file'
 import { contextfileApi } from '../features/context-file/context-file.api'
 import { extractedDataReducer as extractedData } from '../data/extracted'
 import { metadataReducer as metadata } from '../data/metadata'
@@ -12,6 +13,7 @@ import { plotsReducer as plots } from '../features/plots'
 import { tableReducer as table } from '../features/table'
 
 const reducer = combineReducers({
+  contextFile,
   dashboard,
   plots,
   metadata,


### PR DESCRIPTION
This PR persists the Monaco editor view state to the Redux store on unmount. The state then loaded back on mount, which is usually when switching back to the tab.