### PR TITLE
feat(frontend/table): make error tooltip hoverable with copy button

### DIFF
--- a/frontend/packages/ui/src/features/table/components/error-tooltip.tsx
+++ b/frontend/packages/ui/src/features/table/components/error-tooltip.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   ActionIcon,
   Group,
@@ -9,12 +9,7 @@ import {
   useMantineTheme,
 } from '@mantine/core'
 import { IconCheck, IconCopy } from '@tabler/icons-react'
-import {
-  Arrow,
-  type LayerProps,
-  type LayerSide,
-  type UseLayerArrowProps,
-} from 'react-laag'
+import { Arrow, type LayerProps, type UseLayerArrowProps } from 'react-laag'
 
 import { type VariableError } from '../../../types'
 import { errorText, errorVisuals } from '../cells'
@@ -22,45 +17,17 @@ import { errorText, errorVisuals } from '../cells'
 export type ErrorTooltipProps = {
   error: VariableError
   layerProps: LayerProps
-  layerSide: LayerSide
   arrowProps: UseLayerArrowProps
-  bridgePx: number
   onMouseEnter: () => void
   onMouseLeave: () => void
 }
 
 const COPIED_RESET_MS = 1500
 
-// Invisible hover-bridge covering the gap between the cell and the
-// tooltip so that crossing it does not register as hovering an adjacent
-// cell (which would otherwise switch the tooltip's target).
-const bridgeStyle = (side: LayerSide, px: number): CSSProperties => {
-  switch (side) {
-    case 'bottom':
-      return { position: 'absolute', top: -px, left: 0, right: 0, height: px }
-    case 'top':
-      return {
-        position: 'absolute',
-        bottom: -px,
-        left: 0,
-        right: 0,
-        height: px,
-      }
-    case 'right':
-      return { position: 'absolute', left: -px, top: 0, bottom: 0, width: px }
-    case 'left':
-      return { position: 'absolute', right: -px, top: 0, bottom: 0, width: px }
-    default:
-      return { display: 'none' }
-  }
-}
-
 export const ErrorTooltip = ({
   error,
   layerProps,
-  layerSide,
   arrowProps,
-  bridgePx,
   onMouseEnter,
   onMouseLeave,
 }: ErrorTooltipProps) => {
@@ -72,18 +39,13 @@ export const ErrorTooltip = ({
   const scheme = useComputedColorScheme('light')
   const surfaceColor =
     scheme === 'dark' ? theme.colors.dark[5] : theme.colors.dark[7]
-  const borderColor = 'var(--mantine-color-default-border)'
-
-  useEffect(
-    () => () => {
-      window.clearTimeout(resetTimerRef.current)
-    },
-    []
-  )
 
   useEffect(() => {
     window.clearTimeout(resetTimerRef.current)
     setCopied(false)
+    return () => {
+      window.clearTimeout(resetTimerRef.current)
+    }
   }, [error])
 
   const handleCopy = () => {
@@ -115,13 +77,11 @@ export const ErrorTooltip = ({
           '0 0 0 1px var(--mantine-color-default-border), var(--mantine-shadow-md)',
       }}
     >
-      <div style={bridgeStyle(layerSide, bridgePx)} />
       <Arrow
         {...arrowProps}
         backgroundColor={surfaceColor}
-        borderColor={borderColor}
-        borderWidth={1}
-        size={6}
+        borderWidth={0}
+        size={10}
       />
       <Group justify="space-between" gap="md" wrap="nowrap" mb={4}>
         <div>

--- a/frontend/packages/ui/src/features/table/components/error-tooltip.tsx
+++ b/frontend/packages/ui/src/features/table/components/error-tooltip.tsx
@@ -81,6 +81,11 @@ export const ErrorTooltip = ({
     []
   )
 
+  useEffect(() => {
+    window.clearTimeout(resetTimerRef.current)
+    setCopied(false)
+  }, [error])
+
   const handleCopy = () => {
     void navigator.clipboard.writeText(errorText(error)).then(() => {
       setCopied(true)

--- a/frontend/packages/ui/src/features/table/components/error-tooltip.tsx
+++ b/frontend/packages/ui/src/features/table/components/error-tooltip.tsx
@@ -1,42 +1,123 @@
-import { Group, ScrollArea, Text } from '@mantine/core'
+import { type CSSProperties, useEffect, useRef, useState } from 'react'
+import {
+  ActionIcon,
+  Group,
+  ScrollArea,
+  Text,
+  Tooltip,
+  useComputedColorScheme,
+  useMantineTheme,
+} from '@mantine/core'
+import { IconCheck, IconCopy } from '@tabler/icons-react'
+import {
+  Arrow,
+  type LayerProps,
+  type LayerSide,
+  type UseLayerArrowProps,
+} from 'react-laag'
 
 import { type VariableError } from '../../../types'
-import { errorVisuals } from '../cells'
+import { errorText, errorVisuals } from '../cells'
 
-export type ErrorTooltipState = { error: VariableError; x: number; y: number }
+export type ErrorTooltipProps = {
+  error: VariableError
+  layerProps: LayerProps
+  layerSide: LayerSide
+  arrowProps: UseLayerArrowProps
+  bridgePx: number
+  onMouseEnter: () => void
+  onMouseLeave: () => void
+}
 
-/**
- * Hover tooltip for cells of variables that failed to execute. Positioned
- * `fixed` against viewport coordinates, so it needs no positioned ancestor. It
- * is purely informational (`pointerEvents: none`) so it never intercepts the
- * mouse while scanning down a column of errors; see `useErrorTooltip` for the
- * copy-on-Ctrl+C behavior.
- */
+const COPIED_RESET_MS = 1500
+
+// Invisible hover-bridge covering the gap between the cell and the
+// tooltip so that crossing it does not register as hovering an adjacent
+// cell (which would otherwise switch the tooltip's target).
+const bridgeStyle = (side: LayerSide, px: number): CSSProperties => {
+  switch (side) {
+    case 'bottom':
+      return { position: 'absolute', top: -px, left: 0, right: 0, height: px }
+    case 'top':
+      return {
+        position: 'absolute',
+        bottom: -px,
+        left: 0,
+        right: 0,
+        height: px,
+      }
+    case 'right':
+      return { position: 'absolute', left: -px, top: 0, bottom: 0, width: px }
+    case 'left':
+      return { position: 'absolute', right: -px, top: 0, bottom: 0, width: px }
+    default:
+      return { display: 'none' }
+  }
+}
+
 export const ErrorTooltip = ({
   error,
-  x,
-  y,
-  copied,
-}: ErrorTooltipState & { copied: boolean }) => {
+  layerProps,
+  layerSide,
+  arrowProps,
+  bridgePx,
+  onMouseEnter,
+  onMouseLeave,
+}: ErrorTooltipProps) => {
   const { kind, title } = errorVisuals(error.cls)
   const accent = kind === 'error' ? 'red.4' : 'gray.4'
+  const [copied, setCopied] = useState(false)
+  const resetTimerRef = useRef<number>(0)
+  const theme = useMantineTheme()
+  const scheme = useComputedColorScheme('light')
+  const surfaceColor =
+    scheme === 'dark' ? theme.colors.dark[5] : theme.colors.dark[7]
+  const borderColor = 'var(--mantine-color-default-border)'
+
+  useEffect(
+    () => () => {
+      window.clearTimeout(resetTimerRef.current)
+    },
+    []
+  )
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(errorText(error)).then(() => {
+      setCopied(true)
+      window.clearTimeout(resetTimerRef.current)
+      resetTimerRef.current = window.setTimeout(
+        () => setCopied(false),
+        COPIED_RESET_MS
+      )
+    })
+  }
+
+  const { ref: layerRef, style: layerStyle } = layerProps
+
   return (
     <div
+      ref={layerRef}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       style={{
-        position: 'fixed',
-        left: x,
-        top: y + 4,
-        transform: 'translateX(-50%)',
-        zIndex: 100,
+        ...layerStyle,
         maxWidth: 360,
-        background: '#2b2b2b',
-        color: '#fff',
+        background: surfaceColor,
+        color: 'var(--mantine-color-white)',
         borderRadius: 6,
         padding: '8px 10px',
-        boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
-        pointerEvents: 'none',
+        boxShadow:
+          '0 0 0 1px var(--mantine-color-default-border), var(--mantine-shadow-md)',
       }}
     >
+      <div style={bridgeStyle(layerSide, bridgePx)} />
+      <Arrow
+        {...arrowProps}
+        backgroundColor={surfaceColor}
+        borderColor={borderColor}
+        borderWidth={1}
+        size={6}
+      />
       <Group justify="space-between" gap="md" wrap="nowrap" mb={4}>
         <div>
           <Text size="xs" fw={700} c={accent}>
@@ -46,9 +127,24 @@ export const ErrorTooltip = ({
             {error.cls}
           </Text>
         </div>
-        <Text size="xs" c={copied ? 'teal.4' : 'dimmed'}>
-          {copied ? 'Copied' : 'Press ⌘/Ctrl+C to copy'}
-        </Text>
+        <Tooltip
+          label={copied ? 'Copied' : 'Copy'}
+          withArrow
+          styles={{ tooltip: { fontSize: 10, padding: '2px 6px' } }}
+        >
+          <ActionIcon
+            variant="subtle"
+            color="gray"
+            size="sm"
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <IconCheck size={14} color="var(--mantine-color-teal-4)" />
+            ) : (
+              <IconCopy size={14} />
+            )}
+          </ActionIcon>
+        </Tooltip>
       </Group>
       <ScrollArea.Autosize mah={200} type="auto">
         <Text

--- a/frontend/packages/ui/src/features/table/hooks/use-error-tooltip.tsx
+++ b/frontend/packages/ui/src/features/table/hooks/use-error-tooltip.tsx
@@ -49,12 +49,24 @@ export const useErrorTooltip = (
   const tooltipRef = useRef<TooltipState | undefined>(tooltip)
   const closeTimerRef = useRef<number>(0)
   const openTimerRef = useRef<number>(0)
+  const rehoverFrameRef = useRef<number>(0)
   const pendingTargetRef = useRef<TooltipState | null>(null)
   const engagedRef = useRef(false)
+  const cursorRef = useRef<{ x: number; y: number } | null>(null)
 
   useLayoutEffect(() => {
     tooltipRef.current = tooltip
   }, [tooltip])
+
+  useEffect(() => {
+    const onMove = (event: MouseEvent) => {
+      cursorRef.current = { x: event.clientX, y: event.clientY }
+    }
+    window.addEventListener('mousemove', onMove, { passive: true })
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+    }
+  }, [])
 
   const cancelClose = useCallback(() => {
     window.clearTimeout(closeTimerRef.current)
@@ -93,6 +105,37 @@ export const useErrorTooltip = (
     engagedRef.current = false
     setTooltip(undefined)
   }, [cancelClose, cancelOpen])
+
+  // Glide doesn't refire hover after a layout shift. Wait one frame for
+  // the tooltip portal to unmount, then dispatch a synthetic mousemove
+  // so Glide re-evaluates which cell is under the cursor.
+  const rehoverAtCursor = useCallback(() => {
+    const cursor = cursorRef.current
+    if (!cursor) {
+      return
+    }
+    cancelAnimationFrame(rehoverFrameRef.current)
+    rehoverFrameRef.current = requestAnimationFrame(() => {
+      const target = document.elementFromPoint(cursor.x, cursor.y)
+      if (!target) {
+        return
+      }
+      target.dispatchEvent(
+        new MouseEvent('mousemove', {
+          clientX: cursor.x,
+          clientY: cursor.y,
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        })
+      )
+    })
+  }, [])
+
+  const dismissOnScroll = useCallback(() => {
+    dismiss()
+    rehoverAtCursor()
+  }, [dismiss, rehoverAtCursor])
 
   const onBodyEnter = useCallback(() => {
     engagedRef.current = true
@@ -148,6 +191,7 @@ export const useErrorTooltip = (
     () => () => {
       window.clearTimeout(closeTimerRef.current)
       window.clearTimeout(openTimerRef.current)
+      cancelAnimationFrame(rehoverFrameRef.current)
     },
     []
   )
@@ -188,6 +232,7 @@ export const useErrorTooltip = (
   return {
     onItemHovered,
     dismiss,
+    dismissOnScroll,
     tooltip: tooltip
       ? renderLayer(
           <ErrorTooltip

--- a/frontend/packages/ui/src/features/table/hooks/use-error-tooltip.tsx
+++ b/frontend/packages/ui/src/features/table/hooks/use-error-tooltip.tsx
@@ -77,9 +77,17 @@ export const useErrorTooltip = (
         right: iconCenterX + COPY_BUTTON_RIGHT_INSET,
         bottom: args.bounds.y + args.bounds.height,
       }
-      setTooltip((prev) =>
-        prev && prev.error === error ? prev : { error, bounds }
-      )
+      setTooltip((prev) => {
+        if (
+          prev &&
+          prev.error === error &&
+          prev.bounds.left === bounds.left &&
+          prev.bounds.top === bounds.top
+        ) {
+          return prev
+        }
+        return { error, bounds }
+      })
     },
     [lookupError, cancelClose, scheduleClose]
   )

--- a/frontend/packages/ui/src/features/table/hooks/use-error-tooltip.tsx
+++ b/frontend/packages/ui/src/features/table/hooks/use-error-tooltip.tsx
@@ -1,81 +1,132 @@
-import { useCallback, useEffect, useState } from 'react'
-import { type GridMouseEventArgs } from '@glideapps/glide-data-grid'
-
 import {
-  ErrorTooltip,
-  type ErrorTooltipState,
-} from '../components/error-tooltip'
-import { errorText } from '../cells'
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { type GridMouseEventArgs } from '@glideapps/glide-data-grid'
+import { type IBounds, useLayer } from 'react-laag'
+
+import { ErrorTooltip } from '../components/error-tooltip'
 
 import { type VariableError } from '../../../types'
 
-/**
- * Wires the error-tooltip to a `DataEditor`. `lookupError` maps a hovered
- * (col, row) to its `VariableError`, or undefined for cells without an error.
- * Returns the `onItemHovered` handler and the tooltip element to render. While
- * a tooltip is shown, Ctrl/⌘+C copies its message.
- */
+type TooltipState = { error: VariableError; bounds: IBounds }
+
+const ZERO_BOUNDS: IBounds = {
+  left: 0,
+  top: 0,
+  width: 0,
+  height: 0,
+  right: 0,
+  bottom: 0,
+}
+
+const CLOSE_GRACE_MS = 80
+const TRIGGER_OFFSET = 4
+const ICON_SIZE = 20
+const ICON_PADDING = 8
+// 10px tooltip right padding + 26/2 ActionIcon(sm), so `bottom-end` lands
+// the Copy button on the icon column.
+const COPY_BUTTON_RIGHT_INSET = 23
+
 export const useErrorTooltip = (
   lookupError: (col: number, row: number) => VariableError | undefined
 ) => {
-  const [tooltip, setTooltip] = useState<ErrorTooltipState>()
-  const [copied, setCopied] = useState(false)
+  const [tooltip, setTooltip] = useState<TooltipState>()
+  const closeTimerRef = useRef<number>(0)
 
-  // Dismiss the tooltip when the cell is no longer under the mouse for reasons
-  // other than mouse movement (e.g. scrolling, where `onItemHovered` doesn't
-  // fire because the pointer is stationary). Bails out when already hidden so
-  // scroll frames don't schedule needless renders.
-  const dismiss = useCallback(
-    () => setTooltip((prev) => (prev ? undefined : prev)),
-    []
-  )
+  const cancelClose = useCallback(() => {
+    window.clearTimeout(closeTimerRef.current)
+  }, [])
+
+  const scheduleClose = useCallback(() => {
+    window.clearTimeout(closeTimerRef.current)
+    closeTimerRef.current = window.setTimeout(() => {
+      setTooltip(undefined)
+    }, CLOSE_GRACE_MS)
+  }, [])
+
+  const dismiss = useCallback(() => {
+    cancelClose()
+    setTooltip(undefined)
+  }, [cancelClose])
 
   const onItemHovered = useCallback(
     (args: GridMouseEventArgs) => {
       if (args.kind !== 'cell') {
-        dismiss()
+        scheduleClose()
         return
       }
       const [col, row] = args.location
       const error = lookupError(col, row)
       if (!error) {
-        dismiss()
+        scheduleClose()
         return
       }
-      // onItemHovered fires on every pointer move; skip the state update (and
-      // the re-render + keydown re-subscribe it triggers) while the pointer
-      // stays on the same error cell.
-      const x = args.bounds.x + args.bounds.width / 2
-      const y = args.bounds.y + args.bounds.height
+      cancelClose()
+      const iconCenterX =
+        args.bounds.x + args.bounds.width - ICON_PADDING - ICON_SIZE / 2
+      const bounds: IBounds = {
+        left: iconCenterX - COPY_BUTTON_RIGHT_INSET,
+        top: args.bounds.y,
+        width: COPY_BUTTON_RIGHT_INSET * 2,
+        height: args.bounds.height,
+        right: iconCenterX + COPY_BUTTON_RIGHT_INSET,
+        bottom: args.bounds.y + args.bounds.height,
+      }
       setTooltip((prev) =>
-        prev && prev.error === error && prev.x === x && prev.y === y
-          ? prev
-          : { error, x, y }
+        prev && prev.error === error ? prev : { error, bounds }
       )
-      setCopied((prev) => (prev ? false : prev))
     },
-    [lookupError, dismiss]
+    [lookupError, cancelClose, scheduleClose]
   )
 
-  useEffect(() => {
-    if (!tooltip) {
-      return
-    }
-    const onKeyDown = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'c') {
-        e.preventDefault()
-        void navigator.clipboard
-          .writeText(errorText(tooltip.error))
-          .then(() => setCopied(true))
-      }
-    }
-    window.addEventListener('keydown', onKeyDown)
-    return () => window.removeEventListener('keydown', onKeyDown)
+  useEffect(
+    () => () => {
+      window.clearTimeout(closeTimerRef.current)
+    },
+    []
+  )
+
+  // Stable identity so react-laag does not re-subscribe scroll/resize
+  // listeners on every render.
+  const tooltipRef = useRef(tooltip)
+  useLayoutEffect(() => {
+    tooltipRef.current = tooltip
   }, [tooltip])
+  const trigger = useMemo(
+    () => ({ getBounds: () => tooltipRef.current?.bounds ?? ZERO_BOUNDS }),
+    []
+  )
+
+  const { renderLayer, layerProps, layerSide, arrowProps } = useLayer({
+    isOpen: tooltip !== undefined,
+    placement: 'bottom-end',
+    possiblePlacements: ['bottom-end', 'top-end', 'bottom-start', 'top-start'],
+    auto: true,
+    triggerOffset: TRIGGER_OFFSET,
+    container: 'portal',
+    trigger,
+  })
 
   return {
     onItemHovered,
     dismiss,
-    tooltip: tooltip ? <ErrorTooltip {...tooltip} copied={copied} /> : null,
+    tooltip: tooltip
+      ? renderLayer(
+          <ErrorTooltip
+            error={tooltip.error}
+            layerProps={layerProps}
+            layerSide={layerSide}
+            arrowProps={arrowProps}
+            bridgePx={TRIGGER_OFFSET}
+            onMouseEnter={cancelClose}
+            onMouseLeave={scheduleClose}
+          />
+        )
+      : null,
   }
 }

--- a/frontend/packages/ui/src/features/table/hooks/use-error-tooltip.tsx
+++ b/frontend/packages/ui/src/features/table/hooks/use-error-tooltip.tsx
@@ -94,19 +94,13 @@ export const useErrorTooltip = (
     setTooltip(undefined)
   }, [cancelClose, cancelOpen])
 
-  // Body touched: pin the tooltip and treat further switches as deliberate.
   const onBodyEnter = useCallback(() => {
     engagedRef.current = true
     cancelOpen()
     cancelClose()
   }, [cancelClose, cancelOpen])
 
-  // Glide doesn't re-fire onItemHovered for the cell behind the body, so
-  // engagement must pin; close instead comes from off-grid, Escape, or scroll.
   const onBodyLeave = useCallback(() => {
-    if (engagedRef.current) {
-      return
-    }
     scheduleClose()
   }, [scheduleClose])
 

--- a/frontend/packages/ui/src/features/table/hooks/use-error-tooltip.tsx
+++ b/frontend/packages/ui/src/features/table/hooks/use-error-tooltip.tsx
@@ -24,19 +24,37 @@ const ZERO_BOUNDS: IBounds = {
   bottom: 0,
 }
 
-const CLOSE_GRACE_MS = 80
-const TRIGGER_OFFSET = 4
+const CLOSE_GRACE_MS = 1000
+const OPEN_DWELL_MS = 500
+const TRIGGER_OFFSET = 8
 const ICON_SIZE = 20
 const ICON_PADDING = 8
 // 10px tooltip right padding + 26/2 ActionIcon(sm), so `bottom-end` lands
 // the Copy button on the icon column.
 const COPY_BUTTON_RIGHT_INSET = 23
 
+const sameTarget = (
+  a: TooltipState | null | undefined,
+  b: TooltipState
+): boolean =>
+  !!a &&
+  a.error === b.error &&
+  a.bounds.left === b.bounds.left &&
+  a.bounds.top === b.bounds.top
+
 export const useErrorTooltip = (
   lookupError: (col: number, row: number) => VariableError | undefined
 ) => {
   const [tooltip, setTooltip] = useState<TooltipState>()
+  const tooltipRef = useRef<TooltipState | undefined>(tooltip)
   const closeTimerRef = useRef<number>(0)
+  const openTimerRef = useRef<number>(0)
+  const pendingTargetRef = useRef<TooltipState | null>(null)
+  const engagedRef = useRef(false)
+
+  useLayoutEffect(() => {
+    tooltipRef.current = tooltip
+  }, [tooltip])
 
   const cancelClose = useCallback(() => {
     window.clearTimeout(closeTimerRef.current)
@@ -45,72 +63,125 @@ export const useErrorTooltip = (
   const scheduleClose = useCallback(() => {
     window.clearTimeout(closeTimerRef.current)
     closeTimerRef.current = window.setTimeout(() => {
+      engagedRef.current = false
       setTooltip(undefined)
     }, CLOSE_GRACE_MS)
   }, [])
 
+  const cancelOpen = useCallback(() => {
+    window.clearTimeout(openTimerRef.current)
+    pendingTargetRef.current = null
+  }, [])
+
+  const scheduleOpen = useCallback((target: TooltipState) => {
+    window.clearTimeout(openTimerRef.current)
+    if (engagedRef.current) {
+      pendingTargetRef.current = null
+      setTooltip(target)
+      return
+    }
+    pendingTargetRef.current = target
+    openTimerRef.current = window.setTimeout(() => {
+      pendingTargetRef.current = null
+      setTooltip(target)
+    }, OPEN_DWELL_MS)
+  }, [])
+
   const dismiss = useCallback(() => {
+    cancelOpen()
     cancelClose()
+    engagedRef.current = false
     setTooltip(undefined)
-  }, [cancelClose])
+  }, [cancelClose, cancelOpen])
+
+  // Body touched: pin the tooltip and treat further switches as deliberate.
+  const onBodyEnter = useCallback(() => {
+    engagedRef.current = true
+    cancelOpen()
+    cancelClose()
+  }, [cancelClose, cancelOpen])
+
+  // Glide doesn't re-fire onItemHovered for the cell behind the body, so
+  // engagement must pin; close instead comes from off-grid, Escape, or scroll.
+  const onBodyLeave = useCallback(() => {
+    if (engagedRef.current) {
+      return
+    }
+    scheduleClose()
+  }, [scheduleClose])
 
   const onItemHovered = useCallback(
     (args: GridMouseEventArgs) => {
       if (args.kind !== 'cell') {
+        cancelOpen()
         scheduleClose()
         return
       }
       const [col, row] = args.location
       const error = lookupError(col, row)
       if (!error) {
+        cancelOpen()
         scheduleClose()
         return
       }
       cancelClose()
       const iconCenterX =
         args.bounds.x + args.bounds.width - ICON_PADDING - ICON_SIZE / 2
-      const bounds: IBounds = {
-        left: iconCenterX - COPY_BUTTON_RIGHT_INSET,
-        top: args.bounds.y,
-        width: COPY_BUTTON_RIGHT_INSET * 2,
-        height: args.bounds.height,
-        right: iconCenterX + COPY_BUTTON_RIGHT_INSET,
-        bottom: args.bounds.y + args.bounds.height,
+      const target: TooltipState = {
+        error,
+        bounds: {
+          left: iconCenterX - COPY_BUTTON_RIGHT_INSET,
+          top: args.bounds.y,
+          width: COPY_BUTTON_RIGHT_INSET * 2,
+          height: args.bounds.height,
+          right: iconCenterX + COPY_BUTTON_RIGHT_INSET,
+          bottom: args.bounds.y + args.bounds.height,
+        },
       }
-      setTooltip((prev) => {
-        if (
-          prev &&
-          prev.error === error &&
-          prev.bounds.left === bounds.left &&
-          prev.bounds.top === bounds.top
-        ) {
-          return prev
-        }
-        return { error, bounds }
-      })
+      if (sameTarget(tooltipRef.current, target)) {
+        cancelOpen()
+        return
+      }
+      if (sameTarget(pendingTargetRef.current, target)) {
+        return
+      }
+      scheduleOpen(target)
     },
-    [lookupError, cancelClose, scheduleClose]
+    [lookupError, cancelClose, cancelOpen, scheduleClose, scheduleOpen]
   )
 
   useEffect(
     () => () => {
       window.clearTimeout(closeTimerRef.current)
+      window.clearTimeout(openTimerRef.current)
     },
     []
   )
 
+  useEffect(() => {
+    if (!tooltip) {
+      return
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        dismiss()
+      }
+    }
+    // Capture phase: Glide's hidden input swallows keydown in the bubble phase.
+    window.addEventListener('keydown', handleKeyDown, { capture: true })
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, { capture: true })
+    }
+  }, [tooltip, dismiss])
+
   // Stable identity so react-laag does not re-subscribe scroll/resize
   // listeners on every render.
-  const tooltipRef = useRef(tooltip)
-  useLayoutEffect(() => {
-    tooltipRef.current = tooltip
-  }, [tooltip])
   const trigger = useMemo(
     () => ({ getBounds: () => tooltipRef.current?.bounds ?? ZERO_BOUNDS }),
     []
   )
 
-  const { renderLayer, layerProps, layerSide, arrowProps } = useLayer({
+  const { renderLayer, layerProps, arrowProps } = useLayer({
     isOpen: tooltip !== undefined,
     placement: 'bottom-end',
     possiblePlacements: ['bottom-end', 'top-end', 'bottom-start', 'top-start'],
@@ -128,11 +199,9 @@ export const useErrorTooltip = (
           <ErrorTooltip
             error={tooltip.error}
             layerProps={layerProps}
-            layerSide={layerSide}
             arrowProps={arrowProps}
-            bridgePx={TRIGGER_OFFSET}
-            onMouseEnter={cancelClose}
-            onMouseLeave={scheduleClose}
+            onMouseEnter={onBodyEnter}
+            onMouseLeave={onBodyLeave}
           />
         )
       : null,

--- a/frontend/packages/ui/src/features/table/table.tsx
+++ b/frontend/packages/ui/src/features/table/table.tsx
@@ -360,11 +360,18 @@ const Table = ({ grid, paginated = true }: TableProps) => {
     })
   }
 
-  const handleVisibleRegionchange = useCallback(
+  const lastVisibleRectRef = useRef<Rectangle | null>(null)
+  const handleVisibleRegionChange = useCallback(
     (rect: Rectangle) => {
       paginationHandler(rect)
       scrollToViewHandler(rect)
-      dismissErrorTooltip()
+      const previous = lastVisibleRectRef.current
+      const scrolled =
+        !previous || previous.x !== rect.x || previous.y !== rect.y
+      lastVisibleRectRef.current = rect
+      if (scrolled) {
+        dismissErrorTooltip()
+      }
     },
     [paginationHandler, scrollToViewHandler, dismissErrorTooltip]
   )
@@ -395,7 +402,7 @@ const Table = ({ grid, paginated = true }: TableProps) => {
               onItemHovered={handleItemHovered}
               freezeColumns={1}
               customRenderers={CUSTOM_RENDERERS}
-              onVisibleRegionChanged={handleVisibleRegionchange}
+              onVisibleRegionChanged={handleVisibleRegionChange}
               scrollOffsetX={scrollX}
               scrollOffsetY={scrollY}
             />

--- a/frontend/packages/ui/src/features/table/table.tsx
+++ b/frontend/packages/ui/src/features/table/table.tsx
@@ -139,7 +139,7 @@ const Table = ({ grid, paginated = true }: TableProps) => {
   )
   const {
     onItemHovered: handleItemHovered,
-    dismiss: dismissErrorTooltip,
+    dismissOnScroll: dismissErrorTooltipOnScroll,
     tooltip: errorTooltip,
   } = useErrorTooltip(lookupError)
 
@@ -360,20 +360,31 @@ const Table = ({ grid, paginated = true }: TableProps) => {
     })
   }
 
-  const lastVisibleRectRef = useRef<Rectangle | null>(null)
+  const lastVisibleRegionRef = useRef<{
+    rect: Rectangle
+    tx: number
+    ty: number
+  } | null>(null)
   const handleVisibleRegionChange = useCallback(
-    (rect: Rectangle) => {
+    (rect: Rectangle, tx?: number, ty?: number) => {
       paginationHandler(rect)
       scrollToViewHandler(rect)
-      const previous = lastVisibleRectRef.current
+      const previous = lastVisibleRegionRef.current
+      const nextTx = tx ?? 0
+      const nextTy = ty ?? 0
+      // tx/ty catch sub-cell smooth-scroll where rect.x/y stay unchanged.
       const scrolled =
-        !previous || previous.x !== rect.x || previous.y !== rect.y
-      lastVisibleRectRef.current = rect
+        !previous ||
+        previous.rect.x !== rect.x ||
+        previous.rect.y !== rect.y ||
+        previous.tx !== nextTx ||
+        previous.ty !== nextTy
+      lastVisibleRegionRef.current = { rect, tx: nextTx, ty: nextTy }
       if (scrolled) {
-        dismissErrorTooltip()
+        dismissErrorTooltipOnScroll()
       }
     },
-    [paginationHandler, scrollToViewHandler, dismissErrorTooltip]
+    [paginationHandler, scrollToViewHandler, dismissErrorTooltipOnScroll]
   )
 
   return (


### PR DESCRIPTION
An attempt to improve the tooltip UX from #204. This is by using a layer, adding trigger resets, introducing an arrow, and reverting to having a copy button.


https://github.com/user-attachments/assets/330061a8-3735-4630-99af-c5baa4df6c7d

